### PR TITLE
Expand JobInterface to promise the ID, body, NACKs and add. deliveries

### DIFF
--- a/src/Queue/BaseJob.php
+++ b/src/Queue/BaseJob.php
@@ -8,12 +8,77 @@ abstract class BaseJob implements JobInterface
      *
      * @var string
      */
-    private $id;
+    protected $id;
 
     /**
-     * Get job ID
+     * Job body
      *
-     * @return string
+     * This is the job data. Whether just an integer, an array, that depends
+     * on the use case.
+     *
+     * @var mixed
+     */
+    protected $body;
+
+    /**
+     * The number of NACKs this job has received
+     *
+     * NACK is a command which tells Disque that the job wasn't processed
+     * successfully and it should return to the queue immediately.
+     *
+     * @var int
+     */
+    protected $nacks = 0;
+
+    /**
+     * The number of times this job has been re-delivered for reasons other
+     * than a NACK
+     *
+     * @var int
+     */
+    protected $additionalDeliveries = 0;
+
+    /**
+     * An optional shortcut for instantiating the job with one call
+     *
+     * To make it more flexible, all arguments in the constructor are optional
+     * and the job can be populated by calling the setters.
+     *
+     * @param mixed  $body Body            The job body
+     * @param string $id                   The job ID
+     * @param int    $nacks                The number of NACKs
+     * @param int    $additionalDeliveries The number of additional deliveries
+     */
+    public function __construct(
+        $body = null,
+        $id = null,
+        $nacks = 0,
+        $additionalDeliveries = 0
+    ) {
+        $this->body = $body;
+        $this->id = $id;
+        $this->nacks = $nacks;
+        $this->additionalDeliveries = $additionalDeliveries;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * @inheritdoc
      */
     public function getId()
     {
@@ -21,13 +86,42 @@ abstract class BaseJob implements JobInterface
     }
 
     /**
-     * Set job ID
-     *
-     * @param string $id Id
-     * @return void
+     * @inheritdoc
      */
     public function setId($id)
     {
         $this->id = $id;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getNacks()
+    {
+        return $this->nacks;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNacks($nacks)
+    {
+        $this->nacks = $nacks;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAdditionalDeliveries()
+    {
+        return $this->additionalDeliveries;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setAdditionalDeliveries($additionalDeliveries)
+    {
+        $this->additionalDeliveries = $additionalDeliveries;
     }
 }

--- a/src/Queue/Job.php
+++ b/src/Queue/Job.php
@@ -3,40 +3,4 @@ namespace Disque\Queue;
 
 class Job extends BaseJob implements JobInterface
 {
-    /**
-     * Job body
-     *
-     * @var array
-     */
-    private $body = [];
-
-    /**
-     * Build a job with the given body
-     *
-     * @param array $body Body
-     */
-    public function __construct(array $body = [])
-    {
-        $this->setBody($body);
-    }
-
-    /**
-     * Get job body
-     *
-     * @return array Job body
-     */
-    public function getBody()
-    {
-        return $this->body;
-    }
-
-    /**
-     * Set the job body
-     *
-     * @param array $body Body
-     */
-    public function setBody(array $body)
-    {
-        $this->body = $body;
-    }
 }

--- a/src/Queue/JobInterface.php
+++ b/src/Queue/JobInterface.php
@@ -4,17 +4,58 @@ namespace Disque\Queue;
 interface JobInterface
 {
     /**
-     * Get job ID
+     * Get the job ID
      *
      * @return string
      */
     public function getId();
 
     /**
-     * Set job ID
+     * Set the job ID
      *
-     * @param string $id Id
-     * @return void
+     * @param string $id
      */
     public function setId($id);
+
+    /**
+     * Get the job body
+     *
+     * @return mixed Job body
+     */
+    public function getBody();
+
+    /**
+     * Set the job body
+     *
+     * @return mixed $body
+     */
+    public function setBody($body);
+
+    /**
+     * Get the number of NACKs
+     *
+     * @return int
+     */
+    public function getNacks();
+
+    /**
+     * Set the number of NACKs
+     *
+     * @param int $nacks
+     */
+    public function setNacks($nacks);
+
+    /**
+     * Get the number of additional deliveries
+     *
+     * @return int
+     */
+    public function getAdditionalDeliveries();
+
+    /**
+     * Set the number of additional deliveries
+     *
+     * @param int $additionalDeliveries
+     */
+    public function setAdditionalDeliveries($additionalDeliveries);
 }

--- a/src/Queue/Marshal/JobMarshaler.php
+++ b/src/Queue/Marshal/JobMarshaler.php
@@ -4,14 +4,19 @@ namespace Disque\Queue\Marshal;
 use Disque\Queue\Job;
 use Disque\Queue\JobInterface;
 
+/**
+ * Serialize and deserialize the job body
+ *
+ * Serialize the job body when adding the job to the queue,
+ * deserialize it and instantiate a new Job object when reading the job
+ * from the queue.
+ *
+ * This marshaler uses JSON serialization for the whole Job body.
+ */
 class JobMarshaler implements MarshalerInterface
 {
     /**
-     * Creates a JobInterface instance based on data obtained from queue
-     *
-     * @param string $source Source data
-     * @return JobInterface
-     * @throws MarshalException
+     * @inheritdoc
      */
     public function unmarshal($source)
     {
@@ -23,10 +28,7 @@ class JobMarshaler implements MarshalerInterface
     }
 
     /**
-     * Marshals the body of the job ready to be put into the queue
-     *
-     * @param JobInterface $job Job to put in the queue
-     * @return string Source data to be put in the queue
+     * @inheritdoc
      */
     public function marshal(JobInterface $job)
     {

--- a/src/Queue/Marshal/JobMarshaler.php
+++ b/src/Queue/Marshal/JobMarshaler.php
@@ -30,9 +30,6 @@ class JobMarshaler implements MarshalerInterface
      */
     public function marshal(JobInterface $job)
     {
-        if (!($job instanceof Job)) {
-            throw new MarshalException(get_class($job) . ' is not a ' . Job::class);
-        }
         return json_encode($job->getBody());
     }
 }

--- a/tests/Queue/JobTest.php
+++ b/tests/Queue/JobTest.php
@@ -16,26 +16,55 @@ class JobTest extends PHPUnit_Framework_TestCase
     public function testBodyEmpty()
     {
         $j = new Job();
-        $this->assertSame([], $j->getBody());
+        $this->assertNull($j->getBody());
     }
 
     public function testBodyNotEmpty()
     {
-        $j = new Job(['test' => 'stuff']);
-        $this->assertSame(['test' => 'stuff'], $j->getBody());
+        $body = ['test' => 'stuff'];
+        $j = new Job($body);
+        $this->assertSame($body, $j->getBody());
     }
 
-    public function testSetBodyEmpty()
+    public function nullId()
     {
         $j = new Job();
-        $j->setBody([]);
-        $this->assertSame([], $j->getBody());
+        $this->assertNull($j->getId());
     }
 
-    public function testSetBodyNotEmpty()
+    public function idNotNull()
+    {
+        $body = '';
+        $id = 'id';
+        $j = new Job($body, $id);
+        $this->assertSame($id, $j->getId());
+    }
+
+    public function zeroNacks()
     {
         $j = new Job();
-        $j->setBody(['test' => 'stuff']);
-        $this->assertSame(['test' => 'stuff'], $j->getBody());
+        $this->assertSame(0, $j->getNacks());
+    }
+
+    public function nacksSet()
+    {
+        $j = new Job();
+        $nacks = 10;
+        $j->setNacks($nacks);
+        $this->assertSame($nacks, $j->getNacks());
+    }
+
+    public function zeroAdditionalDeliveries()
+    {
+        $j = new Job();
+        $this->assertSame(0, $j->getAdditionalDeliveries());
+    }
+
+    public function additionalDeliveriesSet()
+    {
+        $j = new Job();
+        $deliveries = 10;
+        $j->setAdditionalDeliveries($deliveries);
+        $this->assertSame($deliveries, $j->getAdditionalDeliveries());
     }
 }

--- a/tests/Queue/Marshaler/JobMarshalerTest.php
+++ b/tests/Queue/Marshaler/JobMarshalerTest.php
@@ -23,20 +23,12 @@ class JobMarshalerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(MarshalerInterface::class, $m);
     }
 
-    public function testMarshalInvalid()
-    {
-        $job = m::mock(JobInterface::class);
-        $this->setExpectedException(MarshalException::class, get_class($job) . ' is not a ' . Job::class);
-        $m = new JobMarshaler();
-        $m->marshal($job);
-    }
-
     public function testMarshalEmpty()
     {
         $m = new JobMarshaler();
         $j = new Job();
         $result = $m->marshal($j);
-        $this->assertSame('[]', $result);
+        $this->assertSame('null', $result);
     }
 
     public function testMarshalNotEmpty()


### PR DESCRIPTION
As discussed in #2 this pull request expands the JobInterface to promise all four Disque job properties:

* ID
* Body
* NACKs
* Additional deliveries

This will allow further work on the implementation of WITHCOUNTERS (see #1).

A few notes:

* This is a bc-breaking update but I have tried to keep the breaks to a minimum. The BaseJob constructor accepts the body as the first argument, so all previous uses, tests and documentation examples keep working.
* I have updated the tests to cover the new functionality and fix whatever else I have broken during the refactoring. Let me know whether I kept your testing standards (I'm only used to testing in PHPSpec).
* I have updated the documentation.

Please review the changes and let me know what I should improve and fix.