### PR TITLE
Add the NACK command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -697,6 +697,35 @@ $info = $client->info();
 echo $info;
 ```
 
+### nack
+
+Put the job(s) back to the queue immediately and increment the nack counter.
+
+The command should be used when the worker was not able to process a job and
+wants the job to be put back into the queue in order to be processed again.
+
+It is very similar to ENQUEUE but it increments the job nacks counter
+instead of the additional-deliveries counter.
+
+```php
+nack(string... $ids): int
+```
+
+Arguments:
+
+* `string... $ids`: Each job ID as an argument
+
+Return value:
+
+* `int`: The number of jobs nacked
+
+Example call:
+
+```php
+$jobCount = $client->nack('jobid1', 'jobid2');
+```
+
+
 ### qlen
 
 The length of the queue, that is, the number of jobs available in the given

--- a/docs/README.md
+++ b/docs/README.md
@@ -187,6 +187,18 @@ You do so via the `processed()` method, like so:
 $disque->queue('my_queue')->processed($job);
 ```
 
+If the job failed and you want to retry it, send a negative acknowledgment
+(or `NACK`) with the `failed()` method:
+
+```php
+$disque->queue('my_queue')->failed($job);
+```
+
+This will increase the NACK counter of the job. You can watch the counter and
+if it crosses a threshold, ie. if the job has been retried too many times, you
+can do something else than return it to the queue - move the job to a dead
+letter queue, log it, notify someone etc.
+
 ### Jobs that consume a long time to process
 
 If you are processing a job that requires a long time to be done, it is good

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,6 +18,7 @@ use InvalidArgumentException;
  * @method array getJob(string... $queues, array $options = [)
  * @method array hello()
  * @method string info()
+ * @method int nack(string... $ids)
  * @method int qlen(string $queue)
  * @method array qpeek(string $queue, int $count)
  * @method array qscan(array $options = [])
@@ -71,6 +72,7 @@ class Client
             'GETJOB' => Command\GetJob::class,
             'HELLO' => Command\Hello::class,
             'INFO' => Command\Info::class,
+            'NACK' => Command\Nack::class,
             'QLEN' => Command\QLen::class,
             'QPEEK' => Command\QPeek::class,
             'QSCAN' => Command\QScan::class,

--- a/src/Command/Nack.php
+++ b/src/Command/Nack.php
@@ -1,0 +1,34 @@
+<?php
+namespace Disque\Command;
+
+use Disque\Command\Response\IntResponse;
+
+/**
+ * Put the job(s) back to the queue immediately and increment the nack counter.
+ *
+ * The command should be used when the worker was not able to process a job and
+ * wants the job to be put back into the queue in order to be processed again.
+ *
+ * It is very similar to ENQUEUE but it increments the job nacks counter
+ * instead of the additional-deliveries counter.
+ */
+class Nack extends BaseCommand implements CommandInterface
+{
+    /**
+     * @inheritdoc
+     */
+    protected $argumentsType = self::ARGUMENTS_TYPE_STRINGS;
+    
+    /**
+     * @inheritdoc
+     */
+    protected $responseHandler = IntResponse::class;
+    
+    /**
+     * @inheritdoc
+     */
+    public function getCommand()
+    {
+        return 'NACK';
+    }
+}

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -156,6 +156,19 @@ class Queue
     }
 
     /**
+     * Marks the job as failed and returns it to the queue
+     *
+     * This increases the NACK counter of the job
+     *
+     * @param JobInterface $job
+     */
+    public function failed(JobInterface $job)
+    {
+        $this->checkConnected();
+        $this->client->nack($job->getId());
+    }
+
+    /**
      * Check that we are connected to a node, and if not connect
      *
      * @throws Disque\Connection\ConnectionException

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -100,6 +100,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
             'GETJOB' => Command\GetJob::class,
             'HELLO' => Command\Hello::class,
             'INFO' => Command\Info::class,
+            'NACK' => Command\Nack::class,
             'QLEN' => Command\QLen::class,
             'QPEEK' => Command\QPeek::class,
             'QSCAN' => Command\QScan::class,

--- a/tests/Command/NackTest.php
+++ b/tests/Command/NackTest.php
@@ -1,0 +1,96 @@
+<?php
+namespace Disque\Test\Command;
+
+use PHPUnit_Framework_TestCase;
+use Disque\Command\Argument\InvalidCommandArgumentException;
+use Disque\Command\CommandInterface;
+use Disque\Command\Nack;
+use Disque\Command\Response\InvalidResponseException;
+
+class NackTest extends PHPUnit_Framework_TestCase
+{
+    public function testInstance()
+    {
+        $c = new Nack();
+        $this->assertInstanceOf(CommandInterface::class, $c);
+    }
+    
+    public function testGetCommand()
+    {
+        $c = new Nack();
+        $result = $c->getCommand();
+        $this->assertSame('NACK', $result);
+    }
+    
+    public function testIsBlocking()
+    {
+        $c = new Nack();
+        $result = $c->isBlocking();
+        $this->assertFalse($result);
+    }
+    
+    public function testBuildInvalidArgumentsEmpty()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\Nack: []');
+        $c = new Nack();
+        $c->setArguments([]);
+    }
+    
+    public function testBuildInvalidArgumentsNonStringArray()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\Nack: [["test","stuff"]]');
+        $c = new Nack();
+        $c->setArguments([['test','stuff']]);
+    }
+    
+    public function testBuildInvalidArgumentsNonStringNumeric()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\Nack: [128]');
+        $c = new Nack();
+        $c->setArguments([128]);
+    }
+    
+    public function testBuildInvalidArgumentsEmptyValue()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\Nack: [""]');
+        $c = new Nack();
+        $c->setArguments([""]);
+    }
+    
+    public function testBuild()
+    {
+        $c = new Nack();
+        $c->setArguments(['id']);
+        $result = $c->getArguments();
+        $this->assertSame(['id'], $result);
+    }
+    
+    public function testBuildSeveral()
+    {
+        $c = new Nack();
+        $c->setArguments(['id', 'id2']);
+        $result = $c->getArguments();
+        $this->assertSame(['id', 'id2'], $result);
+    }
+    
+    public function testParseInvalidNonNumericArray()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Nack got: ["test"]');
+        $c = new Nack();
+        $c->parse(['test']);
+    }
+    
+    public function testParseInvalidNonNumericString()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Nack got: "test"');
+        $c = new Nack();
+        $c->parse('test');
+    }
+    
+    public function testParse()
+    {
+        $c = new Nack();
+        $result = $c->parse('128');
+        $this->assertSame(128, $result);
+    }
+}

--- a/tests/Queue/QueueTest.php
+++ b/tests/Queue/QueueTest.php
@@ -195,6 +195,53 @@ class QueueTest extends PHPUnit_Framework_TestCase
         $q->processed($job);
     }
 
+    public function testFailedConnected()
+    {
+        $job = m::mock(JobInterface::class)
+            ->shouldReceive('getId')
+            ->with()
+            ->andReturn('JOB_ID')
+            ->once()
+            ->mock();
+
+        $client = m::mock(Client::class)
+            ->shouldReceive('isConnected')
+            ->with()
+            ->andReturn(true)
+            ->once()
+            ->shouldReceive('nack')
+            ->with('JOB_ID')
+            ->mock();
+
+        $q = new Queue($client, 'queue');
+        $q->failed($job);
+    }
+
+    public function testFailedNotConnected()
+    {
+        $job = m::mock(JobInterface::class)
+            ->shouldReceive('getId')
+            ->with()
+            ->andReturn('JOB_ID')
+            ->once()
+            ->mock();
+
+        $client = m::mock(Client::class)
+            ->shouldReceive('isConnected')
+            ->with()
+            ->andReturn(false)
+            ->once()
+            ->shouldReceive('connect')
+            ->with()
+            ->once()
+            ->shouldReceive('nack')
+            ->with('JOB_ID')
+            ->mock();
+
+        $q = new Queue($client, 'queue');
+        $q->failed($job);
+    }
+
     public function testPullConnected()
     {
         $payload = ['test' => 'stuff'];


### PR DESCRIPTION
Add the NACK command to Not-ACKnowledge a job, return it to the queue immediately and increase its NACK counter.

Add a `Queue::failed()` method as a companion to `Queue::processed()` for marking jobs as failed and returning them to the queue without having to call `Client::nack()`.

Tested and documented.