### PR TITLE
Add support for the GETJOB argument WITHCOUNTERS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -624,6 +624,10 @@ Arguments:
     for jobs. If no jobs are available and this `timeout` expired, then no
     jobs are returned.
   * `count`: an `int`, to specify the number of jobs you wish to obtain.
+  * `withcounters`: a `bool`, if `true`, will fetch the jobs
+     with the `WITHCOUNTERS` argument. The jobs will then contain two
+     additional fields, the counters `nacks` and `additional-deliveries`
+     for failure handling.
 
 Return value:
 
@@ -631,6 +635,24 @@ Return value:
   * `queue`: a `string`, that indicates from which queue this job came from.
   * `id`: a `string`, which is the job ID.
   * `body`: a `string`, which is the payload of the job.
+  * `nacks`: an `int`, the number of `NACKs` received by the job
+  * `additional-deliveries`: an `int`, the number of additional deliveries
+     performed for this job
+  
+The last two fields, `nacks` and `additional-deliveries`, will only be present
+if you call the command with the `withcounters` argument.
+
+What do these two counters mean?
+
+The `nacks` counter is incremented every time a worker uses the `NACK` command
+to tell the queue the job was not processed correctly and should be put back
+on the queue.
+
+The `additional-deliveries` counter is incremented for every other condition
+(different than `NACK` call) that requires a job to be put back on the
+queue again. This includes jobs that get lost and are enqueued again or
+jobs that are delivered multiple times because they time out.
+
 
 Example call:
 

--- a/src/Command/Argument/ArrayChecker.php
+++ b/src/Command/Argument/ArrayChecker.php
@@ -5,7 +5,8 @@ trait ArrayChecker
 {
     /**
      * Check that the exact specified $count arguments are defined,
-     * in a numeric array
+     * in a numeric array and that the array is dense, ie. doesn't contain
+     * any holes in the numeric indexes.
      *
      * @param mixed $elements Elements (should be an array)
      * @param int $count Number of elements expected

--- a/src/Command/GetJob.php
+++ b/src/Command/GetJob.php
@@ -4,6 +4,7 @@ namespace Disque\Command;
 use Disque\Command\Argument\StringChecker;
 use Disque\Command\Argument\InvalidOptionException;
 use Disque\Command\Response\JobsWithQueueResponse;
+use Disque\Command\Response\JobsWithCountersResponse;
 
 class GetJob extends BaseCommand implements CommandInterface
 {
@@ -23,7 +24,8 @@ class GetJob extends BaseCommand implements CommandInterface
      */
     protected $options = [
         'count' => null,
-        'timeout' => null
+        'timeout' => null,
+        'withcounters' => false
     ];
 
     /**
@@ -34,6 +36,7 @@ class GetJob extends BaseCommand implements CommandInterface
     protected $availableArguments = [
         'timeout' => 'TIMEOUT',
         'count' => 'COUNT',
+        'withcounters' => 'WITHCOUNTERS'
     ];
 
     /**
@@ -81,6 +84,11 @@ class GetJob extends BaseCommand implements CommandInterface
                 (isset($options['timeout']) && !is_int($options['timeout']))
             ) {
                 throw new InvalidOptionException($this, $last);
+            }
+
+            if (!empty($options['withcounters'])) {
+                // The response will contain NACKs and additional-deliveries
+                $this->responseHandler = JobsWithCountersResponse::class;
             }
 
             $options = $this->toArguments($options);

--- a/src/Command/Response/JobsResponse.php
+++ b/src/Command/Response/JobsResponse.php
@@ -13,6 +13,16 @@ class JobsResponse extends BaseResponse implements ResponseInterface
     /**
      * Job details for each job
      *
+     * The values in this array must follow these rules:
+     * - The number of the values must be the same as the number of rows
+     *   returned from the respective Disque command
+     * - The order of the values must follow the rows returned by Disque
+     *
+     * The values in $jobDetails will be used as keys in the final response
+     * the command returns.
+     *
+     * @see self::parse()
+     *
      * @var array
      */
     protected $jobDetails = [];
@@ -57,6 +67,12 @@ class JobsResponse extends BaseResponse implements ResponseInterface
     {
         $jobs = [];
         foreach ($this->body as $job) {
+            // To describe this crucial moment in detail: $jobDetails as well as
+            // the $job are numeric arrays with the same number of values.
+            // array_combine() combines them in a new array so that values
+            // from $jobDetails become the keys and values from $job the values.
+            // It's very important that $jobDetails are present in the same
+            // order as the response from Disque.
             $jobs[] = array_combine($this->jobDetails, $job);
         }
         return $jobs;

--- a/src/Command/Response/JobsWithCountersResponse.php
+++ b/src/Command/Response/JobsWithCountersResponse.php
@@ -1,0 +1,75 @@
+<?php
+namespace Disque\Command\Response;
+
+/**
+ * Parse a Disque response of GETJOB with the argument WITHCOUNTERS
+ */
+class JobsWithCountersResponse extends JobsWithQueueResponse implements ResponseInterface
+{
+    const KEY_NACKS = 'nacks';
+    const KEY_ADDITIONAL_DELIVERIES = 'additional-deliveries';
+
+    /**
+     * GETJOB called with WITHCOUNTERS returns a 7-member array for each job.
+     * The value on (zero-based) position #3 is always the string "nacks", the
+     * value on position #5 is always the string "additional-deliveries".
+     *
+     * We want to remove these values from the response.
+     */
+    const DISQUE_RESPONSE_KEY_NACKS = 3;
+    const DISQUE_RESPONSE_KEY_DELIVERIES = 5;
+
+    public function __construct()
+    {
+        // Note: The order of these calls is important as $jobDetails must
+        // match the order of the Disque response rows. Nacks go at the end.
+        parent::__construct();
+        $this->jobDetails = array_merge(
+            $this->jobDetails,
+            [
+                self::KEY_NACKS,
+                self::KEY_ADDITIONAL_DELIVERIES
+            ]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setBody($body)
+    {
+        if (is_null($body)) {
+            $body = [];
+        }
+
+        if (!is_array($body)) {
+            throw new InvalidResponseException($this->command, $body);
+        }
+
+        $jobDetailCount = count($this->jobDetails) + 2;
+
+        /**
+         * Remove superfluous strings from the response
+         * See the comment for the constants defined above
+         */
+        $filteredBody = array_map(
+            function(array $job) use ($jobDetailCount, $body) {
+                if (!$this->checkFixedArray($job, $jobDetailCount)) {
+                    throw new InvalidResponseException($this->command, $body);
+                }
+
+                unset($job[self::DISQUE_RESPONSE_KEY_NACKS]);
+                unset($job[self::DISQUE_RESPONSE_KEY_DELIVERIES]);
+
+                /**
+                 * We must reindex the array so it's dense (without holes)
+                 * @see Disque\Command\Argument\ArrayChecker::checkFixedArray()
+                 */
+                return array_values($job);
+            }, $body);
+
+
+
+        parent::setBody($filteredBody);
+    }
+}

--- a/src/Queue/BaseJob.php
+++ b/src/Queue/BaseJob.php
@@ -8,12 +8,77 @@ abstract class BaseJob implements JobInterface
      *
      * @var string
      */
-    private $id;
+    protected $id;
 
     /**
-     * Get job ID
+     * Job body
      *
-     * @return string
+     * This is the job data. Whether just an integer, an array, that depends
+     * on the use case.
+     *
+     * @var mixed
+     */
+    protected $body;
+
+    /**
+     * The number of NACKs this job has received
+     *
+     * NACK is a command which tells Disque that the job wasn't processed
+     * successfully and it should return to the queue immediately.
+     *
+     * @var int
+     */
+    protected $nacks = 0;
+
+    /**
+     * The number of times this job has been re-delivered for reasons other
+     * than a NACK
+     *
+     * @var int
+     */
+    protected $additionalDeliveries = 0;
+
+    /**
+     * An optional shortcut for instantiating the job with one call
+     *
+     * To make it more flexible, all arguments in the constructor are optional
+     * and the job can be populated by calling the setters.
+     *
+     * @param mixed  $body Body            The job body
+     * @param string $id                   The job ID
+     * @param int    $nacks                The number of NACKs
+     * @param int    $additionalDeliveries The number of additional deliveries
+     */
+    public function __construct(
+        $body = null,
+        $id = null,
+        $nacks = 0,
+        $additionalDeliveries = 0
+    ) {
+        $this->body = $body;
+        $this->id = $id;
+        $this->nacks = $nacks;
+        $this->additionalDeliveries = $additionalDeliveries;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * @inheritdoc
      */
     public function getId()
     {
@@ -21,13 +86,42 @@ abstract class BaseJob implements JobInterface
     }
 
     /**
-     * Set job ID
-     *
-     * @param string $id Id
-     * @return void
+     * @inheritdoc
      */
     public function setId($id)
     {
         $this->id = $id;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getNacks()
+    {
+        return $this->nacks;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNacks($nacks)
+    {
+        $this->nacks = $nacks;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAdditionalDeliveries()
+    {
+        return $this->additionalDeliveries;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setAdditionalDeliveries($additionalDeliveries)
+    {
+        $this->additionalDeliveries = $additionalDeliveries;
     }
 }

--- a/src/Queue/Job.php
+++ b/src/Queue/Job.php
@@ -3,40 +3,4 @@ namespace Disque\Queue;
 
 class Job extends BaseJob implements JobInterface
 {
-    /**
-     * Job body
-     *
-     * @var array
-     */
-    private $body = [];
-
-    /**
-     * Build a job with the given body
-     *
-     * @param array $body Body
-     */
-    public function __construct(array $body = [])
-    {
-        $this->setBody($body);
-    }
-
-    /**
-     * Get job body
-     *
-     * @return array Job body
-     */
-    public function getBody()
-    {
-        return $this->body;
-    }
-
-    /**
-     * Set the job body
-     *
-     * @param array $body Body
-     */
-    public function setBody(array $body)
-    {
-        $this->body = $body;
-    }
 }

--- a/src/Queue/JobInterface.php
+++ b/src/Queue/JobInterface.php
@@ -4,17 +4,58 @@ namespace Disque\Queue;
 interface JobInterface
 {
     /**
-     * Get job ID
+     * Get the job ID
      *
      * @return string
      */
     public function getId();
 
     /**
-     * Set job ID
+     * Set the job ID
      *
-     * @param string $id Id
-     * @return void
+     * @param string $id
      */
     public function setId($id);
+
+    /**
+     * Get the job body
+     *
+     * @return mixed Job body
+     */
+    public function getBody();
+
+    /**
+     * Set the job body
+     *
+     * @return mixed $body
+     */
+    public function setBody($body);
+
+    /**
+     * Get the number of NACKs
+     *
+     * @return int
+     */
+    public function getNacks();
+
+    /**
+     * Set the number of NACKs
+     *
+     * @param int $nacks
+     */
+    public function setNacks($nacks);
+
+    /**
+     * Get the number of additional deliveries
+     *
+     * @return int
+     */
+    public function getAdditionalDeliveries();
+
+    /**
+     * Set the number of additional deliveries
+     *
+     * @param int $additionalDeliveries
+     */
+    public function setAdditionalDeliveries($additionalDeliveries);
 }

--- a/src/Queue/JobInterface.php
+++ b/src/Queue/JobInterface.php
@@ -34,6 +34,10 @@ interface JobInterface
     /**
      * Get the number of NACKs
      *
+     * The `nacks` counter is incremented every time a worker uses the `NACK`
+     * command to tell the queue the job was not processed correctly and should
+     * be put back on the queue.
+     *
      * @return int
      */
     public function getNacks();
@@ -47,6 +51,12 @@ interface JobInterface
 
     /**
      * Get the number of additional deliveries
+     *
+     * The `additional-deliveries` counter is incremented for every other
+     * condition (different than `NACK` call) that requires a job to be put
+     * back on the queue again. This includes jobs that get lost and are
+     * enqueued again or jobs that are delivered multiple times because they
+     * time out.
      *
      * @return int
      */

--- a/src/Queue/Marshal/JobMarshaler.php
+++ b/src/Queue/Marshal/JobMarshaler.php
@@ -4,14 +4,19 @@ namespace Disque\Queue\Marshal;
 use Disque\Queue\Job;
 use Disque\Queue\JobInterface;
 
+/**
+ * Serialize and deserialize the job body
+ *
+ * Serialize the job body when adding the job to the queue,
+ * deserialize it and instantiate a new Job object when reading the job
+ * from the queue.
+ *
+ * This marshaler uses JSON serialization for the whole Job body.
+ */
 class JobMarshaler implements MarshalerInterface
 {
     /**
-     * Creates a JobInterface instance based on data obtained from queue
-     *
-     * @param string $source Source data
-     * @return JobInterface
-     * @throws MarshalException
+     * @inheritdoc
      */
     public function unmarshal($source)
     {
@@ -23,10 +28,7 @@ class JobMarshaler implements MarshalerInterface
     }
 
     /**
-     * Marshals the body of the job ready to be put into the queue
-     *
-     * @param JobInterface $job Job to put in the queue
-     * @return string Source data to be put in the queue
+     * @inheritdoc
      */
     public function marshal(JobInterface $job)
     {

--- a/src/Queue/Marshal/JobMarshaler.php
+++ b/src/Queue/Marshal/JobMarshaler.php
@@ -30,9 +30,6 @@ class JobMarshaler implements MarshalerInterface
      */
     public function marshal(JobInterface $job)
     {
-        if (!($job instanceof Job)) {
-            throw new MarshalException(get_class($job) . ' is not a ' . Job::class);
-        }
         return json_encode($job->getBody());
     }
 }

--- a/tests/Command/Response/JobsWithCountersResponseTest.php
+++ b/tests/Command/Response/JobsWithCountersResponseTest.php
@@ -1,0 +1,170 @@
+<?php
+namespace Disque\Test\Command;
+
+use PHPUnit_Framework_TestCase;
+use Disque\Command\Hello;
+use Disque\Command\Response\ResponseInterface;
+use Disque\Command\Response\JobsWithCountersResponse;
+use Disque\Command\Response\InvalidResponseException;
+use Disque\Command\Response\JobsResponse AS Response;
+use Disque\Command\Response\JobsWithQueueResponse AS Queue;
+use Disque\Command\Response\JobsWithCountersResponse AS Counters;
+
+
+class JobsWithCountersResponseTest extends PHPUnit_Framework_TestCase
+{
+    public function testInstance()
+    {
+        $r = new JobsWithCountersResponse();
+        $this->assertInstanceOf(ResponseInterface::class, $r);
+    }
+    
+    public function testInvalidBodyNotArrayString()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: "test"');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody('test');
+    }
+    
+    public function testInvalidBodyNotArrayNumeric()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: 128');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody(128);
+    }
+    
+    public function testInvalidBodyNotEnoughElementsInJob()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: [["id","body"]]');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody([['id','body']]);
+    }
+    
+    public function testInvalidBodyTooManyElementsInJob()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: [["queue","id","body","test"]]');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody([['queue', 'id', 'body', 'test']]);
+    }
+    
+    public function testParseInvalidArrayElementsNon0()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: [{"1":"test","2":"stuff","3":"more"}]');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody([[1=>'test', 2=>'stuff', 3=>'more']]);
+    }
+    
+    public function testParseInvalidArrayElementsNon1()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: [{"0":"test","2":"stuff","3":"more"}]');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody([[0=>'test', 2=>'stuff', 3=>'more']]);
+    }
+    
+    public function testParseInvalidArrayElementsNon2()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: [{"0":"test","1":"stuff","3":"more"}]');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody([[0=>'test', 1=>'stuff', 3=>'more']]);
+    }
+    
+    public function testInvalidBodyInvalidJobIDPrefix()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: [["queue","XX01234567890","body"]]');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody([['queue', 'XX01234567890', 'body']]);
+    }
+    
+    public function testInvalidBodyInvalidJobIDLength()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\Hello got: [["queue","DI012345","body"]]');
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody([['queue', 'DI012345', 'body']]);
+    }
+    
+    public function testParseNoJob()
+    {
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+        $r->setBody(null);
+        $result = $r->parse();
+        $this->assertSame([], $result);
+    }
+    
+    public function testParseOneJob()
+    {
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+
+        $queue = 'q';
+        $id = 'DI0f0c644fd3ccb51c2cedbd47fcb6f312646c993c05a0SQ';
+        $body = 'lorem ipsum';
+        $nacks = 1;
+        $ad = 2;
+        $response = [$queue, $id, $body, 'nacks', $nacks, 'additional-deliveries', $ad];
+        $r->setBody([$response]);
+        $parsedResponse = $r->parse();
+
+        $this->assertSame([
+            [
+                Queue::KEY_QUEUE => $queue,
+                Response::KEY_ID  => $id,
+                Response::KEY_BODY => $body,
+                Counters::KEY_NACKS => $nacks,
+                Counters::KEY_ADDITIONAL_DELIVERIES => $ad
+            ]
+        ], $parsedResponse);
+    }
+    
+    public function testParseTwoJobs()
+    {
+        $r = new JobsWithCountersResponse();
+        $r->setCommand(new Hello());
+
+        $queue1 = 'q1';
+        $id1 = 'DI0f0c644fd3ccb51c2cedbd47fcb6f312646c993c05a0SQ';
+        $body1 = 'lorem ipsum';
+        $nacks1 = 1;
+        $ad1 = 2;
+
+        $queue2 = 'q2';
+        $id2 = 'DI0f0c644fd3ccb51c2cedbd47fcb6f312646c993c05a0SQ';
+        $body2 = 'dolor sit amet';
+        $nacks2 = 3;
+        $ad2 = 4;
+
+        $response = [
+            [$queue1, $id1, $body1, 'nacks', $nacks1, 'additional-deliveries', $ad1],
+            [$queue2, $id2, $body2, 'nacks', $nacks2, 'additional-deliveries', $ad2],
+        ];
+        $r->setBody($response);
+        $parsedResponse = $r->parse();
+
+        $this->assertSame([
+            [
+                Queue::KEY_QUEUE => $queue1,
+                Response::KEY_ID  => $id1,
+                Response::KEY_BODY => $body1,
+                Counters::KEY_NACKS => $nacks1,
+                Counters::KEY_ADDITIONAL_DELIVERIES => $ad1
+            ],
+            [
+                Queue::KEY_QUEUE => $queue2,
+                Response::KEY_ID  => $id2,
+                Response::KEY_BODY => $body2,
+                Counters::KEY_NACKS => $nacks2,
+                Counters::KEY_ADDITIONAL_DELIVERIES => $ad2
+            ]
+
+        ], $parsedResponse);
+    }
+}

--- a/tests/Queue/JobTest.php
+++ b/tests/Queue/JobTest.php
@@ -16,26 +16,55 @@ class JobTest extends PHPUnit_Framework_TestCase
     public function testBodyEmpty()
     {
         $j = new Job();
-        $this->assertSame([], $j->getBody());
+        $this->assertNull($j->getBody());
     }
 
     public function testBodyNotEmpty()
     {
-        $j = new Job(['test' => 'stuff']);
-        $this->assertSame(['test' => 'stuff'], $j->getBody());
+        $body = ['test' => 'stuff'];
+        $j = new Job($body);
+        $this->assertSame($body, $j->getBody());
     }
 
-    public function testSetBodyEmpty()
+    public function nullId()
     {
         $j = new Job();
-        $j->setBody([]);
-        $this->assertSame([], $j->getBody());
+        $this->assertNull($j->getId());
     }
 
-    public function testSetBodyNotEmpty()
+    public function idNotNull()
+    {
+        $body = '';
+        $id = 'id';
+        $j = new Job($body, $id);
+        $this->assertSame($id, $j->getId());
+    }
+
+    public function zeroNacks()
     {
         $j = new Job();
-        $j->setBody(['test' => 'stuff']);
-        $this->assertSame(['test' => 'stuff'], $j->getBody());
+        $this->assertSame(0, $j->getNacks());
+    }
+
+    public function nacksSet()
+    {
+        $j = new Job();
+        $nacks = 10;
+        $j->setNacks($nacks);
+        $this->assertSame($nacks, $j->getNacks());
+    }
+
+    public function zeroAdditionalDeliveries()
+    {
+        $j = new Job();
+        $this->assertSame(0, $j->getAdditionalDeliveries());
+    }
+
+    public function additionalDeliveriesSet()
+    {
+        $j = new Job();
+        $deliveries = 10;
+        $j->setAdditionalDeliveries($deliveries);
+        $this->assertSame($deliveries, $j->getAdditionalDeliveries());
     }
 }

--- a/tests/Queue/Marshaler/JobMarshalerTest.php
+++ b/tests/Queue/Marshaler/JobMarshalerTest.php
@@ -23,20 +23,12 @@ class JobMarshalerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(MarshalerInterface::class, $m);
     }
 
-    public function testMarshalInvalid()
-    {
-        $job = m::mock(JobInterface::class);
-        $this->setExpectedException(MarshalException::class, get_class($job) . ' is not a ' . Job::class);
-        $m = new JobMarshaler();
-        $m->marshal($job);
-    }
-
     public function testMarshalEmpty()
     {
         $m = new JobMarshaler();
         $j = new Job();
         $result = $m->marshal($j);
-        $this->assertSame('[]', $result);
+        $this->assertSame('null', $result);
     }
 
     public function testMarshalNotEmpty()


### PR DESCRIPTION
This pull request adds support for the `GETJOB` argument `WITHCOUNTERS` (see #1).

`GETJOB WITHCOUNTERS` returns two extra pieces of information for each job:
* The `nacks` counter - the number of times the job has been NACked and returned to the queue for a retry
* The `additional-deliveries` counter - the number of times the job has been requeued for other reasons, eg. worker timeout

These two counters can help the client to handle job failures more precisely. For example, the client may decide to retry a failed job three times, but on the fourth failure remove the job from the queue, move it to a dead letter queue and inform the administrators.

I have added documentation as well as tests according to how other classes are covered.
Please, do a code review and let me know what I should fix and improve.

Two formal notes:
* The pull request has two parts/main commits.
  1. The first one adds support for `WITHCOUNTERS` in `GETJOB`.
  2. The second one makes `WITHCOUNTERS` the default behavior of `Queue::pull()` so that `pull()`-ed jobs automatically contain the counters. Thus if the user goes the easy way and uses `Queue` instead of `Client`, they will be able to read the counters right away.  
If you're not okay with it, we can leave the support just in the Client.
* This pull request is based on the `jobinterface` branch which is not merged yet (see #6). The diff therefore shows also the contents of #6. The `jobinterface` pull request should be reviewed before this. Either Github then automatically adjusts the diff, or I will do a rebase + force pull so that we see the real diff.

Thank you for the code review and any suggestions.