### PR TITLE
Remove the error suppression operator

### DIFF
--- a/src/Queue/Marshal/JobMarshaler.php
+++ b/src/Queue/Marshal/JobMarshaler.php
@@ -20,7 +20,7 @@ class JobMarshaler implements MarshalerInterface
      */
     public function unmarshal($source)
     {
-        $body = @json_decode($source, true);
+        $body = json_decode($source, true);
         if (is_null($body)) {
             throw new MarshalException("Could not deserialize {$source}");
         }


### PR DESCRIPTION
Remove the `@` sign in the JobMarshaler, as discussed in #10, so that it can raise PHP errors.