### PR TITLE
Return null if Queue::pull() finds no job instead of throwing an exception

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -131,17 +131,15 @@ while ($job = $queue->pull()) {
 The call to `pull()` is blocking, so you may find yourself in the need to do 
 something with the time you spend while waiting for jobs. Fortunately `pull()` 
 receives an optional argument: the number of milliseconds to wait for a job. 
-If this time passed and no job was available, a 
-`Disque\Queue\JobNotAvailableException` is thrown. For example if we want to
-wait for jobs, but do something else if after 1 second passed without jobs
-becoming available, and then keep waiting for jobs, we would do:
+If this time passed and no job was available, `null` is returned. For example
+if we want to wait for jobs, but do something else if after 1 second passed
+without jobs becoming available, and then keep waiting for jobs, we would do:
 
 ```php
 $queue = $disque->queue('my_queue');
 while (true) {
-    try {
-        $job = $queue->pull(1000);
-    } catch (\Disque\Queue\JobNotAvailableException $e) {
+    $job = $queue->pull(1000);
+    if (is_null($job)) {
         // Do something else while waiting!
         echo "Still waiting...\n";
         continue;

--- a/src/Queue/JobNotAvailableException.php
+++ b/src/Queue/JobNotAvailableException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Disque\Queue;
-
-class JobNotAvailableException extends QueueException
-{
-}

--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -110,12 +110,11 @@ class Queue
 
     /**
      * Pulls a single job from the queue (if none available, and if $timeout
-     * specified, then wait only this much time for a job, otherwise throw a
-     * `JobNotAvailableException`)
+     * specified, then wait only this much time for a job, otherwise return
+     * `null`)
      *
      * @param int $timeout If specified, wait these many seconds
-     * @return Job
-     * @throws JobNotAvailableException
+     * @return Job|null A job, or null if no job was found before timeout
      */
     public function pull($timeout = 0)
     {
@@ -126,7 +125,7 @@ class Queue
             'withcounters' => true
         ]);
         if (empty($jobs)) {
-            throw new JobNotAvailableException();
+            return null;
         }
         $jobData = $jobs[0];
         $job = $this->marshaler->unmarshal($jobData[Response::KEY_BODY]);

--- a/tests/Queue/QueueTest.php
+++ b/tests/Queue/QueueTest.php
@@ -6,7 +6,6 @@ use DateTimeZone;
 use Disque\Client;
 use Disque\Queue\Job;
 use Disque\Queue\JobInterface;
-use Disque\Queue\JobNotAvailableException;
 use Disque\Queue\Queue;
 use Disque\Queue\Marshal\MarshalerInterface;
 use InvalidArgumentException;
@@ -410,9 +409,8 @@ class QueueTest extends PHPUnit_Framework_TestCase
 
         $q = new Queue($client, 'queue');
 
-        $this->setExpectedException(JobNotAvailableException::class);
-
-        $q->pull();
+        $job = $q->pull();
+        $this->assertNull($job);
     }
 
     public function testPullNoJobsWithTimeout()
@@ -432,9 +430,8 @@ class QueueTest extends PHPUnit_Framework_TestCase
 
         $q = new Queue($client, 'queue');
 
-        $this->setExpectedException(JobNotAvailableException::class);
-
-        $q->pull($timeout);
+        $job = $q->pull($timeout);
+        $this->assertNull($job);
     }
 
     public function testScheduleInvalidDateInPast()


### PR DESCRIPTION
This solves the first comment in #8 - `Queue::pull()` doesn't throw an exception anymore if there's no job found before the time is up. Instead it returns `null`.

Tests and documentation have been changed accordingly.