### PR TITLE
Refactor the registration of commands on the Client

### DIFF
--- a/src/Command/CommandInterface.php
+++ b/src/Command/CommandInterface.php
@@ -4,7 +4,11 @@ namespace Disque\Command;
 interface CommandInterface
 {
     /**
-     * Get command
+     * Get the command name
+     *
+     * The command name determines how the command will be called on Client.
+     * If this method returns "foo", the command must be invoked by calling
+     * the Client::foo() method (the method name is case insensitive)
      *
      * @return string Command
      */


### PR DESCRIPTION
Commands are now registered as objects instead of class names. This allows us
to use type hinting (re #8).
Their name is read from the existing `CommandInterface::getCommand()` method.
This prevents duplicate strings in both the `Client` and the respective command.
The command itself is the source of its name now.