### PR TITLE
Refactor and clean up the Connection\Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,15 @@ pushing/pulling, and direct access to all Disque commands via its
 Create the client:
 
 ```php
-$disque = new \Disque\Client([
-    '127.0.0.1:7111',
-    '127.0.0.2:7112'
-]);
+use Disque\Connection\Credentials;
+use Disque\Client;
+
+$nodes = [
+    new Credentials('127.0.0.1', 7711),
+    new Credentials('127.0.0.1', 7712, 'password'),
+];
+
+$disque = new Client($nodes);
 ```
 
 Queue a job:

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ use Disque\Command;
 use Disque\Command\CommandInterface;
 use Disque\Command\InvalidCommandException;
 use Disque\Connection\Manager;
+use Disque\Connection\ManagerInterface;
 use Disque\Queue\Queue;
 use InvalidArgumentException;
 
@@ -50,6 +51,13 @@ class Client
     private $queues;
 
     /**
+     * A list of credentials to Disque servers
+     *
+     * @var Credentials[]
+     */
+    private $servers;
+
+    /**
      * Create a new Client
      *
      * @param Credentials[] $servers
@@ -76,17 +84,29 @@ class Client
             $this->registerCommand($command);
         }
 
-        $this->connectionManager = new Manager();
+        $this->servers = $servers;
 
-        foreach ($servers as $server) {
+        $connectionManager = new Manager();
+        $this->setConnectionManager($connectionManager);
+    }
+
+    /**
+     * Set a connection manager
+     *
+     * @param ManagerInterface $manager
+     */
+    public function setConnectionManager(ManagerInterface $manager)
+    {
+        $this->connectionManager = $manager;
+        foreach ($this->servers as $server) {
             $this->connectionManager->addServer($server);
         }
     }
 
     /**
-     * Get connection manager
+     * Get the connection manager
      *
-     * @return Manager Connection manager
+     * @return ManagerInterface Connection manager
      */
     public function getConnectionManager()
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,6 +1,7 @@
 <?php
 namespace Disque;
 
+use Disque\Connection\Credentials;
 use Disque\Command;
 use Disque\Command\CommandInterface;
 use Disque\Command\InvalidCommandException;
@@ -15,7 +16,7 @@ use InvalidArgumentException;
  * @method int dequeue(string... $ids)
  * @method int enqueue(string... $ids)
  * @method int fastAck(string... $ids)
- * @method array getJob(string... $queues, array $options = [)
+ * @method array getJob(string... $queues, array $options = [])
  * @method array hello()
  * @method string info()
  * @method int nack(string... $ids)
@@ -51,7 +52,7 @@ class Client
     /**
      * Create a new Client
      *
-     * @param array $servers Servers (`host`:`port`)
+     * @param Credentials[] $servers
      */
     public function __construct(array $servers = [])
     {
@@ -76,22 +77,9 @@ class Client
         }
 
         $this->connectionManager = new Manager();
-        foreach ($servers as $uri) {
-            $port = 7711;
-            if (strpos($uri, ':') !== false) {
-                $server = parse_url($uri);
-                if ($server === false || empty($server['host'])) {
-                    continue;
-                }
-                $host = $server['host'];
-                if (!empty($server['port'])) {
-                    $port = $server['port'];
-                }
-            } else {
-                $host = $uri;
-            }
 
-            $this->addServer($host, $port);
+        foreach ($servers as $server) {
+            $this->connectionManager->addServer($server);
         }
     }
 
@@ -103,21 +91,6 @@ class Client
     public function getConnectionManager()
     {
         return $this->connectionManager;
-    }
-
-    /**
-     * Add a new server
-     *
-     * @param string $host Host
-     * @param int $port Port
-     * @param string $password Password to use when connecting to this server
-     * @param array $options Connection otptions
-     * @return void
-     * @throws InvalidArgumentException
-     */
-    public function addServer($host, $port = 7711, $password = null, array $options = [])
-    {
-        $this->connectionManager->addServer($host, $port, $password, $options);
     }
 
     /**

--- a/src/Command/Response/HelloResponse.php
+++ b/src/Command/Response/HelloResponse.php
@@ -5,6 +5,27 @@ use Disque\Command\Argument\ArrayChecker;
 
 class HelloResponse extends BaseResponse implements ResponseInterface
 {
+    /**
+     * Array keys
+     */
+    const NODE_ID = 'id';
+    const NODE_HOST = 'host';
+    const NODE_PORT = 'port';
+    const NODE_VERSION = 'version';
+    const NODES = 'nodes';
+
+    /**
+     * Position indexes in the Disque response
+     */
+    const POS_VERSION = 0;
+    const POS_ID = 1;
+    const POS_NODES_START = 2;
+
+    const POS_NODE_ID = 0;
+    const POS_NODE_HOST = 1;
+    const POS_NODE_PORT = 2;
+    const POS_NODE_VERSION = 3;
+
     use ArrayChecker;
 
     /**
@@ -35,19 +56,19 @@ class HelloResponse extends BaseResponse implements ResponseInterface
     public function parse()
     {
         $nodes = [];
-        foreach (array_slice($this->body, 2) as $node) {
+        foreach (array_slice($this->body, self::POS_NODES_START) as $node) {
             $nodes[] = [
-                'id' => $node[0],
-                'host' => $node[1],
-                'port' => $node[2],
-                'version' => $node[3]
+                self::NODE_ID => $node[self::POS_NODE_ID],
+                self::NODE_HOST => $node[self::POS_NODE_HOST],
+                self::NODE_PORT => $node[self::POS_NODE_PORT],
+                self::NODE_VERSION => $node[self::POS_NODE_VERSION]
             ];
         }
 
         return [
-            'version' => $this->body[0],
-            'id' => $this->body[1],
-            'nodes' => $nodes
+            self::NODE_VERSION => $this->body[self::POS_VERSION],
+            self::NODE_ID => $this->body[self::POS_ID],
+            self::NODES => $nodes
         ];
     }
 

--- a/src/Command/Response/HelloResponse.php
+++ b/src/Command/Response/HelloResponse.php
@@ -12,6 +12,7 @@ class HelloResponse extends BaseResponse implements ResponseInterface
     const NODE_HOST = 'host';
     const NODE_PORT = 'port';
     const NODE_VERSION = 'version';
+    const NODE_PRIORITY = 'priority';
     const NODES = 'nodes';
 
     /**
@@ -24,7 +25,7 @@ class HelloResponse extends BaseResponse implements ResponseInterface
     const POS_NODE_ID = 0;
     const POS_NODE_HOST = 1;
     const POS_NODE_PORT = 2;
-    const POS_NODE_VERSION = 3;
+    const POS_NODE_PRIORITY = 3;
 
     use ArrayChecker;
 
@@ -61,7 +62,7 @@ class HelloResponse extends BaseResponse implements ResponseInterface
                 self::NODE_ID => $node[self::POS_NODE_ID],
                 self::NODE_HOST => $node[self::POS_NODE_HOST],
                 self::NODE_PORT => $node[self::POS_NODE_PORT],
-                self::NODE_VERSION => $node[self::POS_NODE_VERSION]
+                self::NODE_PRIORITY => $node[self::POS_NODE_PRIORITY]
             ];
         }
 

--- a/src/Command/Response/JobsResponse.php
+++ b/src/Command/Response/JobsResponse.php
@@ -11,6 +11,11 @@ class JobsResponse extends BaseResponse implements ResponseInterface
     const KEY_BODY = 'body';
 
     /**
+     * The position where a node prefix starts in the job ID
+     */
+    const ID_NODE_PREFIX_START = 2;
+
+    /**
      * Job details for each job
      *
      * The values in this array must follow these rules:

--- a/src/Connection/BaseConnection.php
+++ b/src/Connection/BaseConnection.php
@@ -61,7 +61,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Connect
      *
      * @param array $options Connection options
-     * @throws Disque\Connection\Exception\ConnectionException
+     * @throws ConnectionException
      */
     public function connect(array $options = [])
     {

--- a/src/Connection/BaseConnection.php
+++ b/src/Connection/BaseConnection.php
@@ -30,7 +30,7 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
-     * Make sure connection is closed
+     * Make sure the connection is closed
      */
     public function __destruct()
     {
@@ -38,9 +38,7 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
-     * Set host
-     *
-     * @param string $host Host
+     * @inheritdoc
      */
     public function setHost($host)
     {
@@ -48,9 +46,7 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
-     * Set port
-     *
-     * @param int $port Port
+     * @inheritdoc
      */
     public function setPort($port)
     {
@@ -58,12 +54,9 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
-     * Connect
-     *
-     * @param array $options Connection options
-     * @throws ConnectionException
+     * @inheritdoc
      */
-    public function connect(array $options = [])
+    public function connect($connectionTimeout = null, $responseTimeout = null)
     {
         if (!isset($this->host) || !is_string($this->host) || !isset($this->port) || !is_int($this->port)) {
             throw new ConnectionException('Invalid host or port specified');

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -24,11 +24,13 @@ interface ConnectionInterface
     /**
      * Connect
      *
-     * @param array $options Connection options
+     * @param int|null $connectionTimeout Max time to connect, in seconds
+     * @param int|null $responseTimeout   Max time to wait for a response, in s
+     *
      * @return void
      * @throws ConnectionException
      */
-    public function connect(array $options = []);
+    public function connect($connectionTimeout = null, $responseTimeout = null);
 
     /**
      * Disconnect

--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -51,6 +51,7 @@ interface ConnectionInterface
      *
      * @param CommandInterface $command
      * @return mixed Response
+     *
      * @throws ConnectionException
      */
     public function execute(CommandInterface $command);

--- a/src/Connection/Credentials.php
+++ b/src/Connection/Credentials.php
@@ -1,0 +1,132 @@
+<?php
+namespace Disque\Connection;
+
+/**
+ * Identify a Disque server we can connect to
+ *
+ * @package Disque\Connection
+ */
+class Credentials
+{
+    /**
+     * A sprintf format for creating a node address
+     */
+    const ADDRESS_FORMAT = '%s:%d';
+
+    /**
+     * @var string A Disque server host or IP address
+     */
+    private $host;
+    
+    /**
+     * @var int The server port
+     */
+    private $port;
+    
+    /**
+     * @var string|null The password if set for this server
+     */
+    private $password;
+    
+    /**
+     * @var int|null The maximum seconds to wait for a connection to the server
+     */
+    private $connectionTimeout;
+    
+    /**
+     * @var int|null The maximum seconds to wait for a response from the server
+     */
+    private $responseTimeout;
+
+    /**
+     * @param string      $host
+     * @param int         $port
+     * @param string|null $password
+     * @param int|null    $connectionTimeout
+     * @param int|null    $responseTimeout
+     */
+    public function __construct(
+        $host,
+        $port,
+        $password = null,
+        $connectionTimeout = null,
+        $responseTimeout = null
+    ) {
+        $this->host = $host;
+        $this->port = $port;
+        $this->password = $password;
+        $this->connectionTimeout = $connectionTimeout;
+        $this->responseTimeout = $responseTimeout;
+    }
+
+    /**
+     * Get the server host
+     *
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * Get the server port
+     *
+     * @return int
+     */
+    public function getPort()
+    {
+        return $this->port;
+    }
+
+    /**
+     * Get the server address
+     * @return string
+     */
+    public function getAddress()
+    {
+        return sprintf(self::ADDRESS_FORMAT, $this->host, $this->port);
+    }
+
+    /**
+     * Get the password needed to connect to the server
+     *
+     * Passwords in Disque are optional, servers should be secured in other ways
+     *
+     * @return null|string
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * Check if the credentials have a password set
+     *
+     * @return bool
+     */
+    public function havePassword()
+    {
+        return !empty($this->password);
+    }
+
+    /**
+     * Get the maximum time in seconds to wait for a server connection
+     *
+     * @return int|null
+     */
+    public function getConnectionTimeout()
+    {
+        return $this->connectionTimeout;
+    }
+
+    /**
+     * Get the maximum time in seconds to wait for any server response
+     *
+     * @return int|null
+     */
+    public function getResponseTimeout()
+    {
+        return $this->responseTimeout;
+    }
+}

--- a/src/Connection/Factory/ConnectionFactoryInterface.php
+++ b/src/Connection/Factory/ConnectionFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Disque\Connection\Factory;
+
+interface ConnectionFactoryInterface
+{
+    /**
+     * Create a new Connection object
+     *
+     * @param string $host
+     * @param int    $port
+     *
+     * @return ConnectionInterface
+     */
+    public function create($host, $port);
+}

--- a/src/Connection/Factory/PredisFactory.php
+++ b/src/Connection/Factory/PredisFactory.php
@@ -1,0 +1,18 @@
+<?php
+namespace Disque\Connection\Factory;
+
+use Disque\Connection\Predis;
+
+/**
+ * Create the default Disque connection
+ */
+class PredisFactory implements ConnectionFactoryInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function create($host, $port)
+    {
+        return new Predis($host, $port);
+    }
+}

--- a/src/Connection/Factory/SocketFactory.php
+++ b/src/Connection/Factory/SocketFactory.php
@@ -1,0 +1,18 @@
+<?php
+namespace Disque\Connection\Factory;
+
+use Disque\Connection\Socket;
+
+/**
+ * Create the default Disque connection
+ */
+class SocketFactory implements ConnectionFactoryInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function create($host, $port)
+    {
+        return new Socket($host, $port);
+    }
+}

--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -11,7 +11,10 @@ use InvalidArgumentException;
 class Manager implements ManagerInterface
 {
     /**
-     * List of servers
+     * List of servers (or initial nodes) that we can connect to
+     *
+     * After connecting to one, the server returns a list of other nodes
+     * in the cluster.
      *
      * @var array
      */
@@ -25,7 +28,9 @@ class Manager implements ManagerInterface
     protected $minimumJobsToChangeNode = 0;
 
     /**
-     * List of nodes. Indexed by node ID, and as value an array with:
+     * List of nodes, ie Disque instances available in the cluster
+     *
+     * Indexed by node ID, and as value an array with:
      * - ConnectionInterface|null `connection`
      * - string `host`
      * - int `port`
@@ -37,6 +42,10 @@ class Manager implements ManagerInterface
 
     /**
      * Node prefixes, and their corresponding node ID
+     *
+     * Node prefix consists of the first 8 bytes from the node ID. Because job
+     * IDs contain the node prefix, it can be used to identify on which node
+     * a job lives.
      *
      * @var array
      */
@@ -57,9 +66,7 @@ class Manager implements ManagerInterface
     protected $connectionClass = Socket::class;
 
     /**
-     * Get the connection implementation class
-     *
-     * @return string A fully classified class name that implements `ConnectionInterface`
+     * @inheritdoc
      */
     public function getConnectionClass()
     {
@@ -67,11 +74,7 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * Set the connection implementation class
-     *
-     * @param string $class A fully classified class name that must implement `ConnectionInterface`
-     * @return void
-     * @throws InvalidArgumentException
+     * @inheritdoc
      */
     public function setConnectionClass($class)
     {
@@ -82,9 +85,7 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * Get available servers
-     *
-     * @return array Each server is an indexed array with `host` and `port`
+     * @inheritdoc
      */
     public function getServers()
     {
@@ -92,14 +93,7 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * Add a new server
-     *
-     * @param string $host Host
-     * @param int $port Port
-     * @param string $password Password to use when connecting to this server
-     * @param array $options Connection options
-     * @return void
-     * @throws InvalidArgumentException
+     * @inheritdoc
      */
     public function addServer($host, $port = 7711, $password = null, array $options = [])
     {
@@ -112,10 +106,7 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * If a node has produced at least these number of jobs, switch there
-     *
-     * @param int $minimumJobsToChangeNode Set to 0 to never change
-     * @return void
+     * @inheritdoc
      */
     public function setMinimumJobsToChangeNode($minimumJobsToChangeNode)
     {
@@ -123,9 +114,7 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * Tells if connection is established
-     *
-     * @return bool Success
+     * @inheritdoc
      */
     public function isConnected()
     {
@@ -137,11 +126,7 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * Connect to Disque
-     *
-     * @return array Connected node information
-     * @throws AuthenticationException
-     * @throws ConnectionException
+     * @inheritdoc
      */
     public function connect()
     {
@@ -166,11 +151,7 @@ class Manager implements ManagerInterface
     }
 
     /**
-     * Execute the given command on the given connection
-     *
-     * @param CommandInterface $command Command
-     * @return mixed Command response
-     * @throws ConnectionException
+     * @inheritdoc
      */
     public function execute(CommandInterface $command)
     {
@@ -241,6 +222,8 @@ class Manager implements ManagerInterface
      *
      * @param ConnectionInterface $connection Connection
      * @param array $server Server (with `host`, `options', `port`, and `password`)
+     *
+     * @throws AuthenticationException
      */
     private function doConnect(ConnectionInterface $connection, array $server)
     {

--- a/src/Connection/ManagerInterface.php
+++ b/src/Connection/ManagerInterface.php
@@ -75,4 +75,11 @@ interface ManagerInterface
      * @return mixed Command response
      */
     public function execute(CommandInterface $command);
+
+    /**
+     * Get the node we're currently connected to
+     *
+     * @return Node The current node
+     */
+    public function getCurrentNode();
 }

--- a/src/Connection/ManagerInterface.php
+++ b/src/Connection/ManagerInterface.php
@@ -2,51 +2,54 @@
 namespace Disque\Connection;
 
 use Disque\Command\CommandInterface;
+use Disque\Connection\Factory\ConnectionFactoryInterface;
+use Disque\Connection\Node\NodePrioritizerInterface;
 
 interface ManagerInterface
 {
     /**
-     * Get the connection implementation class
+     * Get the connection factory
      *
-     * @return string A fully classified class name that implements `Disque\Connection\ConnectionInterface`
+     * @return ConnectionFactoryInterface
      */
-    public function getConnectionClass();
+    public function getConnectionFactory();
 
     /**
-     * Set the connection implementation class
+     * Set the connection factory
      *
-     * @param string $class A fully classified class name that must implement `Disque\Connection\ConnectionInterface`
-     * @return void
-     * @throws InvalidArgumentException
+     * @param ConnectionFactoryInterface $connectionFactory
      */
-    public function setConnectionClass($class);
+    public function setConnectionFactory(ConnectionFactoryInterface $connectionFactory);
 
     /**
-     * Get available servers
+     * Get credentials to all initially available nodes
      *
-     * @return array Each server is an indexed array with `host` and `port`
+     * @return Credentials[]
      */
-    public function getServers();
+    public function getCredentials();
 
     /**
-     * Add a new server
+     * Add new server credentials
      *
-     * @param string $host Host
-     * @param int $port Port
-     * @param string $password Password to use when connecting to this server
-     * @param array $options Connection options
-     * @return void
-     * @throws InvalidArgumentException
-     */
-    public function addServer($host, $port = 7711, $password = null, array $options = []);
-
-    /**
-     * If a node has produced at least these number of jobs, switch there
+     * @param Credentials $credentials
      *
-     * @param int $minimumJobsToChangeNode Set to 0 to never change
      * @return void
      */
-    public function setMinimumJobsToChangeNode($minimumJobsToChangeNode);
+    public function addServer(Credentials $credentials);
+
+    /**
+     * Get the current node prioritizer
+     *
+     * @return NodePrioritizerInterface
+     */
+    public function getPriorityStrategy();
+
+    /**
+     * Set the node priority strategy
+     *
+     * @param NodePrioritizerInterface $priorityStrategy
+     */
+    public function setPriorityStrategy($priorityStrategy);
 
     /**
      * Tells if connection is established
@@ -58,7 +61,8 @@ interface ManagerInterface
     /**
      * Connect to Disque
      *
-     * @return array Connected node information
+     * @return Node The current node
+     *
      * @throws AuthenticationException
      * @throws ConnectionException
      */

--- a/src/Connection/Node/ConservativeJobCountPrioritizer.php
+++ b/src/Connection/Node/ConservativeJobCountPrioritizer.php
@@ -1,0 +1,107 @@
+<?php
+namespace Disque\Connection\Node;
+
+use InvalidArgumentException;
+
+/**
+ * A prioritizer switching nodes if they have more jobs by a given margin
+ * 
+ * This class prioritizes nodes by job count. Because there is a cost to switch,
+ * it doesn't switch from the current node unless the new candidate has a safe
+ * margin over the current node.
+ * 
+ * This margin can be set manually and defaults to 5%, ie. the new candidate
+ * must have 5% more jobs than the current node.
+ *
+ * This parameter makes the prioritizer behave conservatively - it prefers
+ * the status quo and won't switch immediately if the difference is small.
+ *
+ * You can make the prioritizer eager by setting the margin to 0, or more
+ * conservative by setting it higher. Setting the margin to negative values
+ * is not allowed.
+ */
+class ConservativeJobCountPrioritizer implements NodePrioritizerInterface
+{
+    /**
+     * @var float A margin to switch from the current node
+     *
+     * 0.05 means the new node must have 5% more jobs than the current node
+     * in order to recommend switching over.
+     */
+    private $marginToSwitch = 0.05;
+    
+    /**
+     * Get the margin to switch
+     * 
+     * @return float
+     */
+    public function getMarginToSwitch()
+    {
+        return $this->marginToSwitch;
+    }
+    
+    /**
+     * Set the margin to switch
+     *
+     * @param float $marginToSwitch A positive float or 0
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setMarginToSwitch($marginToSwitch)
+    {
+        if ($marginToSwitch < 0) {
+            throw new InvalidArgumentException('Margin to switch must not be negative');
+        }
+
+        $this->marginToSwitch = $marginToSwitch;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function sort(array $nodes, $currentNodeId)
+    {
+        // Optimize for a "cluster" consisting of just 1 node - skip everything
+        if (count($nodes) === 1) {
+            return $nodes;
+        }
+
+        uasort($nodes, function(Node $nodeA, Node $nodeB) use ($currentNodeId) {
+            $priorityA = $this->calculateNodePriority($nodeA, $currentNodeId);
+            $priorityB = $this->calculateNodePriority($nodeB, $currentNodeId);
+
+            if ($priorityA === $priorityB) {
+                return 0;
+            }
+
+            // Nodes with a higher priority should go first
+            return ($priorityA < $priorityB) ? 1 : -1;
+        });
+
+        return $nodes;
+    }
+
+    /**
+     * Calculate the node priority from its job count, stick to the current node
+     *
+     * As the priority is based on the number of jobs, higher is better.
+     *
+     * @param Node   $node
+     * @param string $currentNodeId
+     *
+     * @return float Node priority
+     */
+    private function calculateNodePriority(Node $node, $currentNodeId)
+    {
+        $priority = $node->getJobCount();
+
+        if ($node->getId() === $currentNodeId) {
+            $margin = 1 + $this->marginToSwitch;
+            $priority = $priority * $margin;
+        }
+
+        return (float) $priority;
+    }
+    
+    
+}

--- a/src/Connection/Node/Node.php
+++ b/src/Connection/Node/Node.php
@@ -1,0 +1,286 @@
+<?php
+namespace Disque\Connection\Node;
+
+use Disque\Connection\Credentials;
+use Disque\Connection\ConnectionInterface;
+use Disque\Command\Auth;
+use Disque\Command\Hello;
+use Disque\Command\Response\HelloResponse;
+use Disque\Connection\ConnectionException;
+use Disque\Connection\AuthenticationException;
+use Disque\Connection\Response\ResponseException;
+
+/**
+ * Describe one Disque node, its properties and the connection to it
+ */
+class Node
+{
+    /**
+     * The response Disque returns if password authentication succeeded
+     */
+    const AUTH_SUCCESS_MESSAGE = 'OK';
+
+    /**
+     * The beginning of a response Disque returns if authentication required
+     */
+    const AUTH_REQUIRED_MESSAGE = 'NOAUTH';
+
+    /**
+     * Node prefix boundaries
+     */
+    const PREFIX_START = 0;
+    const PREFIX_LENGTH = 8;
+
+    /**
+     * @var Credentials Credentials of this node - host, port, password
+     */
+    private $credentials;
+
+    /**
+     * @var ConnectionInterface The connection to this node
+     */
+    private $connection;
+
+    /**
+     * @var string Node ID
+     */
+    private $id;
+
+    /**
+     * @var string Node prefix, or the first 8 bytes of the ID
+     */
+    private $prefix;
+
+    /**
+     * @var int Node HELLO reply version (this is not a Disque version)
+     * This is an integer, see the Disque source code, functions
+     * helloCommand() and addReplyLongLong().
+     */
+    private $version;
+
+    /**
+     * @var array The result of the HELLO command
+     *
+     * @see Disque\Command\Response\HelloResponse
+     */
+    private $hello;
+
+    /**
+     * @var int The number of jobs from this node since the last counter reset
+     *          This counter can be reset, eg. upon a node switch
+     */
+    private $jobCount = 0;
+
+    /**
+     * @var int The number of jobs from this node during its lifetime
+     */
+    private $totalJobCount = 0;
+
+    public function __construct(Credentials $credentials, ConnectionInterface $connection)
+    {
+        $this->credentials = $credentials;
+        $this->connection = $connection;
+    }
+
+    /**
+     * Get the node credentials
+     *
+     * @return Credentials
+     */
+    public function getCredentials()
+    {
+        return $this->credentials;
+    }
+
+    /**
+     * Get the node connection
+     *
+     * @return ConnectionInterface
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * Get the node ID
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the node prefix - the first 8 bytes from the ID
+     *
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * Get the node hello version
+     *
+     * @return int
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Get the node's last HELLO response
+     *
+     * @return array
+     */
+    public function getHello()
+    {
+        return $this->hello;
+    }
+
+    /**
+     * Get the node job count since the last reset (usually a node switch)
+     *
+     * @return int
+     */
+    public function getJobCount()
+    {
+        return $this->jobCount;
+    }
+
+    /**
+     * Increase the node job counts by the given number
+     *
+     * @param int $jobsAdded
+     */
+    public function addJobCount($jobsAdded)
+    {
+        $this->jobCount += $jobsAdded;
+        $this->totalJobCount += $jobsAdded;
+
+    }
+
+    /**
+     *  Reset the node job count
+     */
+    public function resetJobCount()
+    {
+        $this->jobCount = 0;
+    }
+
+    /**
+     * Get the total job count since the node instantiation
+     *
+     * @return int
+     */
+    public function getTotalJobCount()
+    {
+        return $this->totalJobCount;
+    }
+
+    /**
+     * Connect to the node and return the HELLO response
+     *
+     * This method is idempotent and can be called multiple times
+     *
+     * @return array The HELLO response
+     *
+     * @throws ConnectionException
+     * @throws AuthenticationException
+     */
+    public function connect()
+    {
+        if ($this->connection->isConnected() and !empty($this->hello)) {
+            return $this->hello;
+        }
+
+        $this->connectToTheNode();
+        $this->authenticateWithPassword();
+
+        try {
+            $this->sayHello();
+        } catch (ResponseException $e) {
+            /**
+             * If the node requires a password but we didn't supply any,
+             * Disque returns a message "NOAUTH Authentication required"
+             *
+             * HELLO is the first place we would get this error.
+             *
+             * @see https://github.com/antirez/disque/blob/master/src/server.c
+             * Look for "noautherr"
+             */
+            $message = $e->getMessage();
+            if (stripos($message, self::AUTH_REQUIRED_MESSAGE) === 0) {
+                throw new AuthenticationException($message);
+            }
+        }
+
+        return $this->hello;
+    }
+
+    /**
+     * Say a new HELLO to the node and parse the response
+     *
+     * @return array The HELLO response
+     *
+     * @throws ConnectionException
+     */
+    public function sayHello()
+    {
+        $helloCommand = new Hello();
+        $helloResponse = $this->connection->execute($helloCommand);
+        $this->hello = $helloCommand->parse($helloResponse);
+
+        $this->id = $this->hello[HelloResponse::NODE_ID];
+        $this->createPrefix($this->id);
+
+        $this->version = $this->hello[HelloResponse::NODE_VERSION];
+
+        return $this->hello;
+    }
+
+    /**
+     * Connect to the node
+     *
+     * @throws ConnectionException
+     */
+    private function connectToTheNode()
+    {
+        $this->connection->connect(
+            $this->credentials->getConnectionTimeout(),
+            $this->credentials->getResponseTimeout()
+        );
+    }
+
+    /**
+     * Authenticate with the node with a password, if set
+     *
+     * @throws AuthenticationException
+     */
+    private function authenticateWithPassword()
+    {
+        if ($this->credentials->havePassword()) {
+            $authCommand = new Auth();
+            $authCommand->setArguments([$this->credentials->getPassword()]);
+            $authResponse = $this->connection->execute($authCommand);
+            $response = $authCommand->parse($authResponse);
+            if ($response !== self::AUTH_SUCCESS_MESSAGE) {
+                throw new AuthenticationException();
+            }
+        }
+    }
+
+    /**
+     * Create a node prefix from the node ID
+     *
+     * @param string $id
+     */
+    private function createPrefix($id)
+    {
+        $this->prefix = substr($id, self::PREFIX_START, self::PREFIX_LENGTH);
+    }
+}

--- a/src/Connection/Node/NodePrioritizerInterface.php
+++ b/src/Connection/Node/NodePrioritizerInterface.php
@@ -1,0 +1,28 @@
+<?php
+namespace Disque\Connection\Node;
+
+use Traversable;
+
+/**
+ * Sort Disque nodes by priority in order to connect to the most useful one
+ *
+ * The Connection\Manager accepts an implementation of this interface and asks
+ * it to sort nodes by priority. It then tries to connect to the best available
+ * node. The library provides a default implementation.
+ *
+ * In order to make a decision, Nodes have a resettable jobCount,
+ * a totalJobCount and can be extended to accept more markers, eg. latency etc.
+ */
+interface NodePrioritizerInterface
+{
+    /**
+     * Sort the nodes by priority
+     * 
+     * @param Node[] $nodes         A list of known Disque nodes indexed
+     *                              by a node ID
+     * @param string $currentNodeId Node ID of the currently connected node
+     *
+     * @return Traversable|Node[] A list of nodes sorted by priority
+     */
+    public function sort(array $nodes, $currentNodeId);
+}

--- a/src/Connection/Node/NullPrioritizer.php
+++ b/src/Connection/Node/NullPrioritizer.php
@@ -1,0 +1,25 @@
+<?php
+namespace Disque\Connection\Node;
+
+/**
+ * This prioritizer always advises to stay on the current node
+ */
+class NullPrioritizer implements NodePrioritizerInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function sort(array $nodes, $currentNodeId)
+    {
+        if (current($nodes) === $nodes[$currentNodeId]) {
+            return $nodes;
+        }
+
+        // Move the current node to the first place
+        $currentNode = $nodes[$currentNodeId];
+        unset($nodes[$currentNodeId]);
+        array_unshift($nodes, $currentNode);
+
+        return $nodes;
+    }
+}

--- a/src/Connection/Node/RandomPrioritizer.php
+++ b/src/Connection/Node/RandomPrioritizer.php
@@ -1,0 +1,30 @@
+<?php
+namespace Disque\Connection\Node;
+
+/**
+ * This prioritizer advises the Manager to switch nodes randomly
+ *
+ * It can be used to test the availability of nodes in a cluster.
+ */
+class RandomPrioritizer implements NodePrioritizerInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function sort(array $nodes, $currentNodeId)
+    {
+        if (count($nodes) === 1) {
+            return $nodes;
+        }
+
+        $nodeIds = array_keys($nodes);
+        shuffle($nodeIds);
+
+        $shuffledNodes = [];
+        foreach ($nodeIds as $nodeId) {
+            $shuffledNodes[$nodeId] = $nodes[$nodeId];
+        }
+
+        return $shuffledNodes;
+    }
+}

--- a/src/Connection/Predis.php
+++ b/src/Connection/Predis.php
@@ -14,20 +14,19 @@ class Predis extends BaseConnection implements ConnectionInterface
     protected $client;
 
     /**
-     * Connect
-     *
-     * @param array $options Connection options
+     * @inheritdoc
      */
-    public function connect(array $options = [])
+    public function connect($connectionTimeout = null, $responseTimeout = null)
+
     {
-        parent::connect($options);
+        parent::connect($connectionTimeout, $responseTimeout);
 
         $this->client = $this->buildClient($this->host, $this->port);
         $this->client->connect();
     }
 
     /**
-     * Disconnect
+     * @inheritdoc
      */
     public function disconnect()
     {
@@ -39,9 +38,7 @@ class Predis extends BaseConnection implements ConnectionInterface
     }
 
     /**
-     * Tells if connection is established
-     *
-     * @return bool Success
+     * @inheritdoc
      */
     public function isConnected()
     {
@@ -49,11 +46,7 @@ class Predis extends BaseConnection implements ConnectionInterface
     }
 
     /**
-     * Execute command, and get response
-     *
-     * @param CommandInterface $command
-     * @return mixed Response
-     * @throws ConnectionException
+     * @inheritdoc
      */
     public function execute(CommandInterface $command)
     {

--- a/src/Connection/Response/ArrayResponse.php
+++ b/src/Connection/Response/ArrayResponse.php
@@ -1,6 +1,8 @@
 <?php
 namespace Disque\Connection\Response;
 
+use Disque\Connection\ConnectionException;
+
 class ArrayResponse extends BaseResponse
 {
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -11,6 +11,7 @@ use Disque\Command\CommandInterface;
 use Disque\Command\InvalidCommandException;
 use Disque\Connection\ManagerInterface;
 use Disque\Connection\ConnectionException;
+use Disque\Connection\Credentials;
 use Disque\Queue\Queue;
 
 class MockClient extends Client
@@ -43,43 +44,26 @@ class ClientTest extends PHPUnit_Framework_TestCase
     public function testConstruct()
     {
         $c = new MockClient();
-        $this->assertSame([], $c->getConnectionManager()->getServers());
+        $this->assertSame([], $c->getConnectionManager()->getCredentials());
     }
 
     public function testConstructNoServers()
     {
         $c = new MockClient([]);
-        $this->assertSame([], $c->getConnectionManager()->getServers());
-    }
-
-    public function testConstructInvalidServers()
-    {
-        $c = new MockClient([':7711']);
-        $this->assertSame([], $c->getConnectionManager()->getServers());
+        $this->assertSame([], $c->getConnectionManager()->getCredentials());
     }
 
     public function testConstructMultipleServers()
     {
-        $c = new MockClient([
-            '127.0.0.1:7711',
-            '127.0.0.1:7712',
-        ]);
-        $this->assertEquals([
-            ['host' => '127.0.0.1', 'port' => 7711, 'password' => null, 'options' => []],
-            ['host' => '127.0.0.1', 'port' => 7712, 'password' => null, 'options' => []],
-        ], $c->getConnectionManager()->getServers());
-    }
+        $nodes = [
+            new Credentials('127.0.0.1', '7711'),
+            new Credentials('127.0.0.1', '7712'),
+        ];
 
-    public function testConstructMultipleServersDefaultPort()
-    {
-        $c = new MockClient([
-            '127.0.0.1',
-            '127.0.0.1:7712',
-        ]);
-        $this->assertEquals([
-            ['host' => '127.0.0.1', 'port' => 7711, 'password' => null, 'options' => []],
-            ['host' => '127.0.0.1', 'port' => 7712, 'password' => null, 'options' => []],
-        ], $c->getConnectionManager()->getServers());
+        $c = new Client($nodes);
+        $this->assertEquals(
+            $nodes,
+            array_values($c->getConnectionManager()->getCredentials()));
     }
 
     public function testCommandsRegistered()

--- a/tests/Command/HelloTest.php
+++ b/tests/Command/HelloTest.php
@@ -145,7 +145,7 @@ class HelloTest extends PHPUnit_Framework_TestCase
     public function testParse()
     {
         $c = new Hello();
-        $result = $c->parse(['version', 'id', ['id', 'host', 'port', 'version']]);
+        $result = $c->parse(['version', 'id', ['id', 'host', 'port', 'pri']]);
         $this->assertSame([
             'version' => 'version',
             'id' => 'id',
@@ -154,7 +154,7 @@ class HelloTest extends PHPUnit_Framework_TestCase
                     'id' => 'id',
                     'host' => 'host',
                     'port' => 'port',
-                    'version' => 'version'
+                    'priority' => 'pri'
                 ]
             ]
         ], $result);

--- a/tests/Command/Response/HelloResponseTest.php
+++ b/tests/Command/Response/HelloResponseTest.php
@@ -59,7 +59,8 @@ class HelloResponseTest extends PHPUnit_Framework_TestCase
     {
         $r = new HelloResponse();
         $r->setCommand(new Hello());
-        $r->setBody(['version', 'id', ['id', 'host', 'port', 'version']]);
+
+        $r->setBody(['version', 'id', ['id', 'host', 'port', 'priority']]);
         $result = $r->parse();
         $this->assertSame([
             'version' => 'version',
@@ -69,7 +70,7 @@ class HelloResponseTest extends PHPUnit_Framework_TestCase
                     'id' => 'id',
                     'host' => 'host',
                     'port' => 'port',
-                    'version' => 'version'
+                    'priority' => 'priority'
                 ]
             ]
         ], $result);
@@ -82,8 +83,8 @@ class HelloResponseTest extends PHPUnit_Framework_TestCase
         $r->setBody([
             'version',
             'id',
-            ['id', 'host', 'port', 'version'],
-            ['id2', 'host2', 'port2', 'version2'],
+            ['id', 'host', 'port', '1'],
+            ['id2', 'host2', 'port2', '2'],
         ]);
         $result = $r->parse();
         $this->assertSame([
@@ -94,13 +95,13 @@ class HelloResponseTest extends PHPUnit_Framework_TestCase
                     'id' => 'id',
                     'host' => 'host',
                     'port' => 'port',
-                    'version' => 'version'
+                    'priority' => '1'
                 ],
                 [
                     'id' => 'id2',
                     'host' => 'host2',
                     'port' => 'port2',
-                    'version' => 'version2'
+                    'priority' => '2'
                 ]
             ]
         ], $result);

--- a/tests/Connection/CredentialsTest.php
+++ b/tests/Connection/CredentialsTest.php
@@ -1,0 +1,99 @@
+<?php
+namespace Disque\Test\Connection;
+
+use Mockery as m;
+use Disque\Connection\Credentials;
+
+class CredentialsTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testInstance()
+    {
+        $c = new Credentials('127.0.0.1', 1111);
+        $this->assertInstanceOf(Credentials::class, $c);
+    }
+
+    public function testGetHost()
+    {
+        $host = '127.0.0.1';
+        $port = 1234;
+        $c = new Credentials($host, $port);
+        $this->assertSame($host, $c->getHost());
+    }
+
+    public function testGetPort()
+    {
+        $host = '127.0.0.1';
+        $port = 1234;
+        $c = new Credentials($host, $port);
+        $this->assertSame($port, $c->getPort());
+    }
+
+    public function testGetAddress()
+    {
+        $host = '127.0.0.1';
+        $port = 1234;
+        $address = '127.0.0.1:1234';
+        $c = new Credentials($host, $port);
+        $this->assertSame($address, $c->getAddress());
+    }
+
+    public function testDefaultValues()
+    {
+        $host = '127.0.0.1';
+        $port = 1234;
+        $c = new Credentials($host, $port);
+        $this->assertNull($c->getPassword());
+        $this->assertFalse($c->havePassword());
+        $this->assertNull($c->getConnectionTimeout());
+        $this->assertNull($c->getResponseTimeout());
+    }
+
+    public function testGetPassword()
+    {
+        $host = '127.0.0.1';
+        $port = 1234;
+        $password = 'password';
+        $c = new Credentials($host, $port, $password);
+        $this->assertSame($password, $c->getPassword());
+    }
+
+    public function testHavePassword()
+    {
+        $host = '127.0.0.1';
+        $port = 1234;
+        $password1 = null;
+        $c = new Credentials($host, $port, $password1);
+        $this->assertFalse($c->havePassword());
+
+        $password2 = 'password';
+        $c2 = new Credentials($host, $port, $password2);
+        $this->assertTrue($c2->havePassword());
+    }
+
+    public function testGetConnectionTimeout()
+    {
+        $host = '127.0.0.1';
+        $port = 1234;
+        $password = null;
+        $connectionTimeout = 1000;
+        $c = new Credentials($host, $port, $password, $connectionTimeout);
+        $this->assertSame($connectionTimeout, $c->getConnectionTimeout());
+    }
+
+    public function testGetResponseTimeout()
+    {
+        $host = '127.0.0.1';
+        $port = 1234;
+        $password = null;
+        $connectionTimeout = 1000;
+        $responseTimeout = 2000;
+        $c = new Credentials($host, $port, $password, $connectionTimeout, $responseTimeout);
+        $this->assertSame($responseTimeout, $c->getResponseTimeout());
+    }
+}

--- a/tests/Connection/Factory/PredisFactoryTest.php
+++ b/tests/Connection/Factory/PredisFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Disque\Test\Connection\Factory;
+
+use Disque\Connection\Factory\PredisFactory;
+use Disque\Connection\Predis;
+use Mockery as m;
+
+class PredisFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testInstance()
+    {
+        $f = new PredisFactory();
+        $this->assertInstanceOf(PredisFactory::class, $f);
+    }
+
+    public function testCreate()
+    {
+        $host = '127.0.0.1';
+        $port = 7711;
+
+        $f = new PredisFactory();
+        $socket = $f->create($host, $port);
+
+        $this->assertInstanceOf(Predis::class, $socket);
+    }
+}

--- a/tests/Connection/Factory/SocketFactoryTest.php
+++ b/tests/Connection/Factory/SocketFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Disque\Test\Connection\Factory;
+
+use Disque\Connection\Factory\SocketFactory;
+use Disque\Connection\Socket;
+use Mockery as m;
+
+class SocketFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testInstance()
+    {
+        $f = new SocketFactory();
+        $this->assertInstanceOf(SocketFactory::class, $f);
+    }
+
+    public function testCreate()
+    {
+        $host = '127.0.0.1';
+        $port = 7711;
+
+        $f = new SocketFactory();
+        $socket = $f->create($host, $port);
+
+        $this->assertInstanceOf(Socket::class, $socket);
+    }
+}

--- a/tests/Connection/ManagerTest.php
+++ b/tests/Connection/ManagerTest.php
@@ -91,6 +91,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
 
         $nodeId = 'id1';
         $version = 'v1';
+        $priority = 10;
 
         $server = new Credentials($serverAddress, $serverPort);
         $m->addServer($server);
@@ -102,7 +103,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
                 HelloResponse::POS_NODE_ID => $nodeId,
                 HelloResponse::POS_NODE_HOST => $serverAddress,
                 HelloResponse::POS_NODE_PORT => $serverPort,
-                HelloResponse::POS_NODE_VERSION => $version
+                HelloResponse::POS_NODE_PRIORITY => $priority
             ]
         ];
 
@@ -122,7 +123,6 @@ class ManagerTest extends PHPUnit_Framework_TestCase
             ->with($serverAddress, $serverPort)
             ->andReturn($connection)
             ->once()
-
             ->getMock();
 
         $m->setConnectionFactory($connectionFactory);
@@ -130,7 +130,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($connection, $node->getConnection());
         $this->assertSame($nodeId, $node->getId());
-        $this->assertSame($version, $node->getVersion());
+        $this->assertSame($priority, $node->getPriority());
         $this->assertSame($server, $node->getCredentials());
     }
 
@@ -313,6 +313,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
 
         $nodeId = 'id1';
         $version = 'v1';
+        $priority = 2;
 
         $helloResponse = [
             HelloResponse::POS_VERSION => $version,
@@ -321,7 +322,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
                 HelloResponse::POS_NODE_ID => $nodeId,
                 HelloResponse::POS_NODE_HOST => $serverAddress,
                 HelloResponse::POS_NODE_PORT => $serverPort,
-                HelloResponse::POS_NODE_VERSION => $version
+                HelloResponse::POS_NODE_PRIORITY => $priority
             ]
         ];
 
@@ -349,7 +350,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($connection, $node->getConnection());
         $this->assertSame($nodeId, $node->getId());
-        $this->assertSame($version, $node->getVersion());
+        $this->assertSame($priority, $node->getPriority());
         $this->assertSame($server, $node->getCredentials());
 
     }
@@ -368,6 +369,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
 
         $nodeId = 'id1';
         $version = 'v1';
+        $priority = 5;
 
         $connection = m::mock(ConnectionInterface::class)
             ->shouldReceive('isConnected')
@@ -380,7 +382,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
             ->once()
             ->shouldReceive('execute')
             ->with(m::type(Hello::class))
-            ->andReturn([$version, $nodeId, [$nodeId, $serverAddress, $serverPort2, $version]])
+            ->andReturn([$version, $nodeId, [$nodeId, $serverAddress, $serverPort2, $priority]])
             ->once()
             ->mock();
 
@@ -395,7 +397,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($connection, $node->getConnection());
         $this->assertSame($nodeId, $node->getId());
-        $this->assertSame($version, $node->getVersion());
+        $this->assertSame($priority, $node->getPriority());
         $this->assertContains($node->getCredentials(), [$server1, $server2]);
     }
 
@@ -444,7 +446,7 @@ class ManagerTest extends PHPUnit_Framework_TestCase
                 HelloResponse::POS_NODE_ID => $nodeId,
                 HelloResponse::POS_NODE_HOST => $serverAddress,
                 HelloResponse::POS_NODE_PORT => $serverPort,
-                HelloResponse::POS_NODE_VERSION => $version
+                HelloResponse::POS_NODE_PRIORITY => $version
             ]
         ];
         $expectedResponse = ['test' => 'stuff'];

--- a/tests/Connection/Node/ConservativeJobCountPrioritizerTest.php
+++ b/tests/Connection/Node/ConservativeJobCountPrioritizerTest.php
@@ -1,0 +1,149 @@
+<?php
+namespace Disque\Test\Connection\Node;
+
+use Disque\Connection\Node\ConservativeJobCountPrioritizer;
+use Disque\Connection\Node\Node;
+use InvalidArgumentException;
+use Mockery as m;
+
+class ConservativeJobCountPrioritizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testInstance()
+    {
+        $p = new ConservativeJobCountPrioritizer();
+        $this->assertInstanceOf(ConservativeJobCountPrioritizer::class, $p);
+    }
+
+    public function testDefaultMarginToSwitch()
+    {
+        $p = new ConservativeJobCountPrioritizer();
+        $this->assertSame(0.05, $p->getMarginToSwitch());
+    }
+
+    public function testSetMarginToSwitch()
+    {
+        $marginToSwitch = 0.5;
+        $p = new ConservativeJobCountPrioritizer();
+        $p->setMarginToSwitch($marginToSwitch);
+        $this->assertSame($marginToSwitch, $p->getMarginToSwitch());
+    }
+
+    public function testSetInvalidMarginToSwitch()
+    {
+        $marginToSwitch = -0.5;
+        $p = new ConservativeJobCountPrioritizer();
+        $this->setExpectedException(InvalidArgumentException::class, 'Margin to switch must not be negative');
+        $p->setMarginToSwitch($marginToSwitch);
+    }
+
+    public function testSortWithDefaultMarginToSwitch()
+    {
+        $nodeId1 = 'id1';
+        $nodeId2 = 'id2';
+        $nodeId3 = 'id3';
+        $node1 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(100)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId1)
+            ->getMock();
+        $node2 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(104)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId2)
+            ->getMock();
+        $node3 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(106)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId3)
+            ->getMock();
+
+        $nodes = [
+            $nodeId1 => $node1,
+            $nodeId2 => $node2
+        ];
+        $expectedNodes = $nodes;
+        $p = new ConservativeJobCountPrioritizer();
+        $resultNodes = $p->sort($nodes, $nodeId1);
+        $this->assertSame($expectedNodes, $resultNodes);
+
+        $nodes2 = [
+            $nodeId1 => $node1,
+            $nodeId3 => $node3
+        ];
+        $expectedNodes2 = [
+            $nodeId3 => $node3,
+            $nodeId1 => $node1
+        ];
+        $resultNodes2 = $p->sort($nodes2, $node1);
+        $this->assertSame($expectedNodes2, $resultNodes2);
+    }
+
+    public function testSingleNodeIsNotSorted()
+    {
+        $nodeId1 = 'id1';
+        $node1 = m::mock(Node::class);
+        $nodes = [$nodeId1 => $node1];
+
+        $p = new ConservativeJobCountPrioritizer();
+        $resultNodes = $p->sort($nodes, $nodeId1);
+        $this->assertSame($nodes, $resultNodes);
+    }
+
+    public function testSortWithCustomMargin()
+    {
+        $nodeId1 = 'id1';
+        $nodeId2 = 'id2';
+        $nodeId3 = 'id3';
+        $node1 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(100)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId1)
+            ->getMock();
+        $node2 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(149)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId2)
+            ->getMock();
+        $node3 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(151)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId3)
+            ->getMock();
+
+        $nodes = [
+            $nodeId1 => $node1,
+            $nodeId2 => $node2
+        ];
+        $expectedNodes = $nodes;
+        $p = new ConservativeJobCountPrioritizer();
+        $p->setMarginToSwitch(0.5);
+        $resultNodes = $p->sort($nodes, $nodeId1);
+        $this->assertSame($expectedNodes, $resultNodes);
+
+        $nodes2 = [
+            $nodeId1 => $node1,
+            $nodeId3 => $node3
+        ];
+        $expectedNodes2 = [
+            $nodeId3 => $node3,
+            $nodeId1 => $node1
+        ];
+        $resultNodes2 = $p->sort($nodes2, $node1);
+        $this->assertSame($expectedNodes2, $resultNodes2);
+    }
+
+
+
+}

--- a/tests/Connection/Node/ConservativeJobCountPrioritizerTest.php
+++ b/tests/Connection/Node/ConservativeJobCountPrioritizerTest.php
@@ -52,18 +52,24 @@ class ConservativeJobCountPrioritizerTest extends \PHPUnit_Framework_TestCase
             ->andReturn(100)
             ->shouldReceive('getId')
             ->andReturn($nodeId1)
+            ->shouldReceive('getPriority')
+            ->andReturn(1)
             ->getMock();
         $node2 = m::mock(Node::class)
             ->shouldReceive('getJobCount')
             ->andReturn(104)
             ->shouldReceive('getId')
             ->andReturn($nodeId2)
+            ->shouldReceive('getPriority')
+            ->andReturn(1)
             ->getMock();
         $node3 = m::mock(Node::class)
             ->shouldReceive('getJobCount')
             ->andReturn(106)
             ->shouldReceive('getId')
             ->andReturn($nodeId3)
+            ->shouldReceive('getPriority')
+            ->andReturn(1)
             ->getMock();
 
         $nodes = [
@@ -108,18 +114,24 @@ class ConservativeJobCountPrioritizerTest extends \PHPUnit_Framework_TestCase
             ->andReturn(100)
             ->shouldReceive('getId')
             ->andReturn($nodeId1)
+            ->shouldReceive('getPriority')
+            ->andReturn(1)
             ->getMock();
         $node2 = m::mock(Node::class)
             ->shouldReceive('getJobCount')
             ->andReturn(149)
             ->shouldReceive('getId')
             ->andReturn($nodeId2)
+            ->shouldReceive('getPriority')
+            ->andReturn(1)
             ->getMock();
         $node3 = m::mock(Node::class)
             ->shouldReceive('getJobCount')
             ->andReturn(151)
             ->shouldReceive('getId')
             ->andReturn($nodeId3)
+            ->shouldReceive('getPriority')
+            ->andReturn(1)
             ->getMock();
 
         $nodes = [
@@ -144,6 +156,92 @@ class ConservativeJobCountPrioritizerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedNodes2, $resultNodes2);
     }
 
+    public function testSortWithDifferentDisquePriority()
+    {
+        $nodeId1 = 'id1';
+        $nodeId2 = 'id2';
+        $nodeId3 = 'id3';
+        $node1 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(100)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId1)
+            ->shouldReceive('getPriority')
+            ->andReturn(1)
+            ->getMock();
 
+        $node2 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(190)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId2)
+            ->shouldReceive('getPriority')
+            ->andReturn(9)
+            ->getMock();
+
+        $node3 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(250)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId3)
+            ->shouldReceive('getPriority')
+            ->andReturn(9)
+            ->getMock();
+
+        $nodes = [
+            $nodeId1 => $node1,
+            $nodeId2 => $node2
+        ];
+        $expectedNodes = $nodes;
+        $p = new ConservativeJobCountPrioritizer();
+        $resultNodes = $p->sort($nodes, $nodeId1);
+        $this->assertSame($expectedNodes, $resultNodes);
+
+        $nodes2 = [
+            $nodeId1 => $node1,
+            $nodeId3 => $node3
+        ];
+        $expectedNodes2 = [
+            $nodeId3 => $node3,
+            $nodeId1 => $node1
+        ];
+        $resultNodes2 = $p->sort($nodes2, $node1);
+        $this->assertSame($expectedNodes2, $resultNodes2);
+    }
+
+    public function testDeprioritizeFailingNodes()
+    {
+        $nodeId1 = 'id1';
+        $nodeId2 = 'id2';
+        $nodeId3 = 'id3';
+        $node1 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(100)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId1)
+            ->shouldReceive('getPriority')
+            ->andReturn(1)
+            ->getMock();
+
+        // Priority 100 marks this as a failing node. Regardless of its job
+        // count, it should have the lowest priority when switching.
+        $node2 = m::mock(Node::class)
+            ->shouldReceive('getJobCount')
+            ->andReturn(9999)
+            ->shouldReceive('getId')
+            ->andReturn($nodeId2)
+            ->shouldReceive('getPriority')
+            ->andReturn(100)
+            ->getMock();
+
+        $nodes = [
+            $nodeId1 => $node1,
+            $nodeId2 => $node2
+        ];
+        $expectedNodes = $nodes;
+        $p = new ConservativeJobCountPrioritizer();
+        $resultNodes = $p->sort($nodes, $nodeId1);
+        $this->assertSame($expectedNodes, $resultNodes);
+    }
 
 }

--- a/tests/Connection/Node/NodeTest.php
+++ b/tests/Connection/Node/NodeTest.php
@@ -1,0 +1,342 @@
+<?php
+namespace Disque\Test\Connection\Node;
+
+use Disque\Command\Auth;
+use Disque\Command\Hello;
+use Disque\Command\Response\HelloResponse;
+use Disque\Command\Response\InvalidResponseException;
+use Disque\Connection\AuthenticationException;
+use Disque\Connection\ConnectionException;
+use Disque\Connection\ConnectionInterface;
+use Disque\Connection\Credentials;
+use Disque\Connection\Node\Node;
+use Disque\Connection\Response\ResponseException;
+use Mockery as m;
+
+class NodeTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testInstance()
+    {
+        $credentials = m::mock(Credentials::class);
+        $connection = m::mock(ConnectionInterface::class);
+        $n = new Node($credentials, $connection);
+        $this->assertInstanceOf(Node::class, $n);
+    }
+
+    public function testGetConnection()
+    {
+        $credentials = m::mock(Credentials::class);
+        $connection = m::mock(ConnectionInterface::class);
+        $n = new Node($credentials, $connection);
+        $this->assertSame($connection, $n->getConnection());
+    }
+
+    public function testGetCredentials()
+    {
+        $credentials = m::mock(Credentials::class);
+        $connection = m::mock(ConnectionInterface::class);
+        $n = new Node($credentials, $connection);
+        $this->assertSame($credentials, $n->getCredentials());
+    }
+
+    public function testDefaultValues()
+    {
+        $credentials = m::mock(Credentials::class);
+        $connection = m::mock(ConnectionInterface::class);
+        $n = new Node($credentials, $connection);
+
+        $this->assertSame(0, $n->getJobCount());
+        $this->assertSame(0, $n->getTotalJobCount());
+        $this->assertNull($n->getId());
+        $this->assertNull($n->getPrefix());
+        $this->assertNull($n->getVersion());
+        $this->assertNull($n->getHello());
+    }
+
+    public function testJobCount()
+    {
+        $credentials = m::mock(Credentials::class);
+        $connection = m::mock(ConnectionInterface::class);
+        $n = new Node($credentials, $connection);
+
+        $jobs1 = 2;
+        $jobs2 = 3;
+        $totalJobs = $jobs1 + $jobs2;
+
+        $n->addJobCount($jobs1);
+        $n->addJobCount($jobs2);
+
+        $this->assertSame($totalJobs, $n->getJobCount());
+        $this->assertSame($totalJobs, $n->getTotalJobCount());
+    }
+
+    public function testResetJobCount()
+    {
+        $credentials = m::mock(Credentials::class);
+        $connection = m::mock(ConnectionInterface::class);
+        $n = new Node($credentials, $connection);
+
+        $totalJobs = 5;
+
+        $n->addJobCount($totalJobs);
+        $n->resetJobCount();
+
+        $this->assertSame(0, $n->getJobCount());
+        $this->assertSame($totalJobs, $n->getTotalJobCount());
+    }
+
+    public function testSayHello()
+    {
+        $address = '127.0.0.1';
+        $port = 7712;
+        $nodeId = 'someLongNodeId';
+        $prefix = 'someLong';
+        $version = 'v1';
+        $helloResponse = [
+            HelloResponse::POS_VERSION => $version,
+            HelloResponse::POS_ID => $nodeId,
+            HelloResponse::POS_NODES_START => [
+                HelloResponse::POS_NODE_ID => $nodeId,
+                HelloResponse::POS_NODE_HOST => $address,
+                HelloResponse::POS_NODE_PORT => $port,
+                HelloResponse::POS_NODE_VERSION => $version
+            ]
+        ];
+        $expectedHello = [
+            HelloResponse::NODE_VERSION => $version,
+            HelloResponse::NODE_ID => $nodeId,
+            HelloResponse::NODES => [
+                [
+                    HelloResponse::NODE_ID => $nodeId,
+                    HelloResponse::NODE_HOST => $address,
+                    HelloResponse::NODE_PORT => $port,
+                    HelloResponse::NODE_VERSION => $version
+                ]
+            ]
+        ];
+
+        $credentials = m::mock(Credentials::class);
+        $connection = m::mock(ConnectionInterface::class)
+            ->shouldReceive('execute')
+            ->andReturn($helloResponse)
+            ->getMock();
+        $n = new Node($credentials, $connection);
+        $hello = $n->sayHello();
+
+        $this->assertSame($expectedHello, $hello);
+        $this->assertNotNull($n->getHello());
+        $this->assertSame($nodeId, $n->getId());
+        $this->assertSame($version, $n->getVersion());
+        $this->assertSame($prefix, $n->getPrefix());
+
+    }
+
+    public function testSayHelloConnectionException()
+    {
+        $credentials = m::mock(Credentials::class);
+        $connection = m::mock(ConnectionInterface::class)
+            ->shouldReceive('execute')
+            ->andThrow(new ConnectionException())
+            ->getMock();
+        $n = new Node($credentials, $connection);
+
+        $this->setExpectedException(ConnectionException::class);
+        $n->sayHello();
+    }
+
+    public function testConnect()
+    {
+        $connectionTimeout = 1000;
+        $responseTimeout = 1000;
+        $address = '127.0.0.1';
+        $port = 7712;
+        $nodeId = 'someLongNodeId';
+        $version = 'v1';
+        $helloResponse = [
+            HelloResponse::POS_VERSION => $version,
+            HelloResponse::POS_ID => $nodeId,
+            HelloResponse::POS_NODES_START => [
+                HelloResponse::POS_NODE_ID => $nodeId,
+                HelloResponse::POS_NODE_HOST => $address,
+                HelloResponse::POS_NODE_PORT => $port,
+                HelloResponse::POS_NODE_VERSION => $version
+            ]
+        ];
+        $expectedHello = [
+            HelloResponse::NODE_VERSION => $version,
+            HelloResponse::NODE_ID => $nodeId,
+            HelloResponse::NODES => [
+                [
+                    HelloResponse::NODE_ID => $nodeId,
+                    HelloResponse::NODE_HOST => $address,
+                    HelloResponse::NODE_PORT => $port,
+                    HelloResponse::NODE_VERSION => $version
+                ]
+            ]
+        ];
+        $credentials = m::mock(Credentials::class)
+            ->shouldReceive('getConnectionTimeout')
+            ->andReturn($connectionTimeout)
+            ->shouldReceive('getResponseTimeout')
+            ->andReturn($responseTimeout)
+            ->shouldReceive('havePassword')
+            ->andReturn(false)
+            ->getMock();
+        $connection = m::mock(ConnectionInterface::class)
+            ->shouldReceive('isConnected')
+            ->andReturn(false)
+            ->shouldReceive('connect')
+            ->shouldReceive('execute')
+            ->andReturn($helloResponse)
+            ->getMock();
+
+        $n = new Node($credentials, $connection);
+        $hello = $n->connect();
+        $this->assertSame($expectedHello, $hello);
+    }
+
+    public function testConnectConnectionException()
+    {
+        $connectionTimeout = 1000;
+        $responseTimeout = 1000;
+        $credentials = m::mock(Credentials::class)
+            ->shouldReceive('getConnectionTimeout')
+            ->andReturn($connectionTimeout)
+            ->shouldReceive('getResponseTimeout')
+            ->andReturn($responseTimeout)
+            ->getMock();
+        $connection = m::mock(ConnectionInterface::class)
+            ->shouldReceive('isConnected')
+            ->andReturn(false)
+            ->shouldReceive('connect')
+            ->andThrow(new ConnectionException())
+            ->getMock();
+        $n = new Node($credentials, $connection);
+        $this->setExpectedException(ConnectionException::class);
+        $n->connect();
+    }
+
+
+    public function testConnectWithPasswordRightPassword()
+    {
+        $connectionTimeout = 1000;
+        $responseTimeout = 1000;
+        $address = '127.0.0.1';
+        $port = 7712;
+        $nodeId = 'someLongNodeId';
+        $version = 'v1';
+        $password = 'password';
+        $helloResponse = [
+            HelloResponse::POS_VERSION => $version,
+            HelloResponse::POS_ID => $nodeId,
+            HelloResponse::POS_NODES_START => [
+                HelloResponse::POS_NODE_ID => $nodeId,
+                HelloResponse::POS_NODE_HOST => $address,
+                HelloResponse::POS_NODE_PORT => $port,
+                HelloResponse::POS_NODE_VERSION => $version
+            ]
+        ];
+        $expectedHello = [
+            HelloResponse::NODE_VERSION => $version,
+            HelloResponse::NODE_ID => $nodeId,
+            HelloResponse::NODES => [
+                [
+                    HelloResponse::NODE_ID => $nodeId,
+                    HelloResponse::NODE_HOST => $address,
+                    HelloResponse::NODE_PORT => $port,
+                    HelloResponse::NODE_VERSION => $version
+                ]
+            ]
+        ];
+        $credentials = m::mock(Credentials::class)
+            ->shouldReceive('getConnectionTimeout')
+            ->andReturn($connectionTimeout)
+            ->shouldReceive('getResponseTimeout')
+            ->andReturn($responseTimeout)
+            ->shouldReceive('havePassword')
+            ->andReturn(true)
+            ->shouldReceive('getPassword')
+            ->andReturn($password)
+            ->getMock();
+        $connection = m::mock(ConnectionInterface::class)
+            ->shouldReceive('isConnected')
+            ->andReturn(false)
+            ->shouldReceive('connect')
+            ->shouldReceive('execute')
+            ->andReturn('OK')
+            ->once()
+            ->shouldReceive('execute')
+            ->andReturn($helloResponse)
+            ->once()
+            ->getMock();
+
+        $n = new Node($credentials, $connection);
+        $hello = $n->connect();
+        $this->assertSame($expectedHello, $hello);
+    }
+
+    public function testConnectWithPasswordMissingPassword()
+    {
+        $connectionTimeout = 1000;
+        $responseTimeout = 1000;
+
+        $credentials = m::mock(Credentials::class)
+            ->shouldReceive('getConnectionTimeout')
+            ->andReturn($connectionTimeout)
+            ->shouldReceive('getResponseTimeout')
+            ->andReturn($responseTimeout)
+            ->shouldReceive('havePassword')
+            ->andReturn(false)
+            ->getMock();
+        $connection = m::mock(ConnectionInterface::class)
+            ->shouldReceive('isConnected')
+            ->andReturn(false)
+            ->shouldReceive('connect')
+            ->shouldReceive('execute')
+            ->with(m::type(Hello::class))
+            ->andThrow(new ResponseException('NOAUTH Authentication Required'))
+            ->once()
+            ->getMock();
+
+        $n = new Node($credentials, $connection);
+        $this->setExpectedException(AuthenticationException::class);
+        $n->connect();
+    }
+
+    public function testConnectWithPasswordWrongPassword()
+    {
+        $connectionTimeout = 1000;
+        $responseTimeout = 1000;
+        $wrongPassword = 'wrongPassword';
+
+        $credentials = m::mock(Credentials::class)
+            ->shouldReceive('getConnectionTimeout')
+            ->andReturn($connectionTimeout)
+            ->shouldReceive('getResponseTimeout')
+            ->andReturn($responseTimeout)
+            ->shouldReceive('havePassword')
+            ->andReturn(true)
+            ->shouldReceive('getPassword')
+            ->andReturn($wrongPassword)
+            ->getMock();
+        $connection = m::mock(ConnectionInterface::class)
+            ->shouldReceive('isConnected')
+            ->andReturn(false)
+            ->shouldReceive('connect')
+            ->shouldReceive('execute')
+            ->with(m::type(Auth::class))
+            ->andReturn('whatever')
+            ->once()
+            ->getMock();
+
+        $n = new Node($credentials, $connection);
+        $this->setExpectedException(AuthenticationException::class);
+        $n->connect();
+    }
+}

--- a/tests/Connection/Node/NodeTest.php
+++ b/tests/Connection/Node/NodeTest.php
@@ -55,7 +55,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(0, $n->getTotalJobCount());
         $this->assertNull($n->getId());
         $this->assertNull($n->getPrefix());
-        $this->assertNull($n->getVersion());
+        $this->assertSame(1, $n->getPriority());
         $this->assertNull($n->getHello());
     }
 
@@ -98,6 +98,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $nodeId = 'someLongNodeId';
         $prefix = 'someLong';
         $version = 'v1';
+        $priority = 1;
         $helloResponse = [
             HelloResponse::POS_VERSION => $version,
             HelloResponse::POS_ID => $nodeId,
@@ -105,7 +106,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
                 HelloResponse::POS_NODE_ID => $nodeId,
                 HelloResponse::POS_NODE_HOST => $address,
                 HelloResponse::POS_NODE_PORT => $port,
-                HelloResponse::POS_NODE_VERSION => $version
+                HelloResponse::POS_NODE_PRIORITY => $priority
             ]
         ];
         $expectedHello = [
@@ -116,7 +117,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
                     HelloResponse::NODE_ID => $nodeId,
                     HelloResponse::NODE_HOST => $address,
                     HelloResponse::NODE_PORT => $port,
-                    HelloResponse::NODE_VERSION => $version
+                    HelloResponse::NODE_PRIORITY => $priority
                 ]
             ]
         ];
@@ -132,7 +133,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedHello, $hello);
         $this->assertNotNull($n->getHello());
         $this->assertSame($nodeId, $n->getId());
-        $this->assertSame($version, $n->getVersion());
+        $this->assertSame($priority, $n->getPriority());
         $this->assertSame($prefix, $n->getPrefix());
 
     }
@@ -165,7 +166,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
                 HelloResponse::POS_NODE_ID => $nodeId,
                 HelloResponse::POS_NODE_HOST => $address,
                 HelloResponse::POS_NODE_PORT => $port,
-                HelloResponse::POS_NODE_VERSION => $version
+                HelloResponse::POS_NODE_PRIORITY => $version
             ]
         ];
         $expectedHello = [
@@ -176,7 +177,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
                     HelloResponse::NODE_ID => $nodeId,
                     HelloResponse::NODE_HOST => $address,
                     HelloResponse::NODE_PORT => $port,
-                    HelloResponse::NODE_VERSION => $version
+                    HelloResponse::NODE_PRIORITY => $version
                 ]
             ]
         ];
@@ -239,7 +240,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
                 HelloResponse::POS_NODE_ID => $nodeId,
                 HelloResponse::POS_NODE_HOST => $address,
                 HelloResponse::POS_NODE_PORT => $port,
-                HelloResponse::POS_NODE_VERSION => $version
+                HelloResponse::POS_NODE_PRIORITY => $version
             ]
         ];
         $expectedHello = [
@@ -250,7 +251,7 @@ class NodeTest extends \PHPUnit_Framework_TestCase
                     HelloResponse::NODE_ID => $nodeId,
                     HelloResponse::NODE_HOST => $address,
                     HelloResponse::NODE_PORT => $port,
-                    HelloResponse::NODE_VERSION => $version
+                    HelloResponse::NODE_PRIORITY => $version
                 ]
             ]
         ];

--- a/tests/Connection/Node/NullPrioritizerTest.php
+++ b/tests/Connection/Node/NullPrioritizerTest.php
@@ -1,0 +1,54 @@
+<?php
+namespace Disque\Test\Connection\Node;
+
+use Disque\Connection\Node\NullPrioritizer;
+use Mockery as m;
+
+class NullPrioritizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testInstance()
+    {
+        $p = new NullPrioritizer();
+        $this->assertInstanceOf(NullPrioritizer::class, $p);
+    }
+
+    public function testSortFirstNode()
+    {
+        $nodeId1 = 'id1';
+        $nodeId2 = 'id2';
+        $nodes = [
+            $nodeId1 => $nodeId1,
+            $nodeId2 => $nodeId2
+        ];
+        $nodesExpected = [
+            $nodeId1 => $nodeId1,
+            $nodeId2 => $nodeId2
+        ];
+        $p = new NullPrioritizer();
+        $nodesResult = $p->sort($nodes, $nodeId1);
+        $this->assertSame($nodesExpected, $nodesResult);
+    }
+
+    public function testSortSecondNode()
+    {
+        $nodeId1 = 'id1';
+        $nodeId2 = 'id2';
+        $nodes = [
+            $nodeId2 => $nodeId2,
+            $nodeId1 => $nodeId1
+        ];
+        $nodesExpected = [
+            $nodeId1 => $nodeId1,
+            $nodeId2 => $nodeId2
+        ];
+        $p = new NullPrioritizer();
+        $nodesResult = $p->sort($nodes, $nodeId1);
+        $this->assertSame(array_values($nodesExpected), array_values($nodesResult));
+    }
+}

--- a/tests/Connection/Node/RandomPrioritizerTest.php
+++ b/tests/Connection/Node/RandomPrioritizerTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace Disque\Test\Connection\Node;
+
+use Disque\Connection\Node\Node;
+use Disque\Connection\Node\RandomPrioritizer;
+use Mockery as m;
+
+class RandomPrioritizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testInstance()
+    {
+        $p = new RandomPrioritizer();
+        $this->assertInstanceOf(RandomPrioritizer::class, $p);
+    }
+
+    public function testSort()
+    {
+        $nodeId1 = 'id1';
+        $nodeId2 = 'id2';
+
+        $node1 = m::mock(Node::class);
+        $node2 = m::mock(Node::class);
+
+        $nodes = [$nodeId1 => $node1, $nodeId2 => $node2];
+
+        $possibleResults = [
+            [$nodeId1 => $node1, $nodeId2 => $node2],
+            [$nodeId2 => $node2, $nodeId1 => $node1]
+        ];
+
+        $p = new RandomPrioritizer();
+        $result = $p->sort($nodes, $nodeId1);
+        $this->assertContains($result, $possibleResults);
+    }
+}


### PR DESCRIPTION
I haven't left, I was working. :) And here is the result.

Let me explain why this is a larger change than what we were talking about in #12. I started working on the ConnectionBuilder/Factory. I went through the code and made notes about what actually happens where, how the code flows and how it could be simplified. Once I started pulling on one thread - creating a connection - the class started tumbling down and it became clear that I would have to rewrite most of it.

What does this pull request change and why?

* Replace the associative arrays in `$servers` and `$nodes` with objects - `Credentials` and `Node`. This provides a more intuitive interface, type hinting and code completion. Also rename `$servers` to `$credentials`.
* Use the password from `Credentials` not only for the initial connection, but also for any later revealed nodes, if the `Credentials` match the node. Thus there can be multiple password-protected nodes in the cluster and the library will be able to connect to them, provided the user has supplied working credentials.
* Each `Node` object takes care and keeps track of its own connection as well as node stats (like job count)
* Move the node prioritization out of the `Manager` into a `NodePrioritizer`. Since the prioritization is implemented via a Strategy pattern, the user can swap the default prioritizer for any prioritizer from the ones that are already included by default or that they write
* The node prioritization asks the prioritizer to sort all known nodes and tries to switch to the first working one, skipping failed nodes (formerly the algorithm tried to connect to just one node)
* Move the stats tracking as well as the prioritization out of the `execute()` method so the behavior can be easily overridden, eg. if the user wants to track different or more stats than just the job count
* Say `HELLO` to a node each time we connect to it and reveal the current cluster topology anew. The library may be used in long-running scripts and the cluster topology may change while it runs. Saying `HELLO` repeatedly will detect possible cluster changes (formerly the `HELLO` command was issued only during the initial connection)
* Fix the `HELLO` response parsing. We overlooked that the last field in a node description was not its version, but its priority as assigned by Disque
* Use the Disque-assigned node priority in the default prioritizer

I tried to split the work into logical commits, but it was sometimes hard to find the right boundaries as I was working on many interconnected things at once in a few files. Thus sometimes work on one feature might have overflown into another commit.

The code is tested and documented. 

A colleague of mine helped me write the tests and did an informal code review that uncovered several bugs, so the changes have already been read by a pair of eyes. It would still be useful, however, if you could take a careful look at the proposed changes.

Thank you. I'm looking forward to your thoughts and critique.