### PR TITLE
We should reconnect if not connected

### DIFF
--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -401,7 +401,7 @@ class Manager implements ManagerInterface
     private function switchToNode(Node $node)
     {
         $nodeId = $node->getId();
-        if ($this->nodeId === $nodeId) {
+        if (($this->nodeId === $nodeId) && $this->isConnected()) {
             return;
         }
 


### PR DESCRIPTION
I have no idea on how to test this.
I've come to this problem where a one queue processor adds to another queue and thus a new disque client is made. to push a job to another queue. And somewhat the connection in original disque client is dropped.