### PR TITLE
Reconnect, if the current node has lost its connection

### DIFF
--- a/src/Connection/Node/Node.php
+++ b/src/Connection/Node/Node.php
@@ -2,6 +2,7 @@
 namespace Disque\Connection\Node;
 
 use Disque\Command\Auth;
+use Disque\Command\CommandInterface;
 use Disque\Command\Hello;
 use Disque\Command\Response\HelloResponse;
 use Disque\Connection\ConnectionException;
@@ -255,6 +256,29 @@ class Node
         }
 
         return $this->hello;
+    }
+
+    /**
+     * Check if this object holds a working connection to Disque node
+     *
+     * @return bool
+     */
+    public function isConnected()
+    {
+        return $this->connection->isConnected();
+    }
+
+    /**
+     * Execute a command on this Disque node
+     *
+     * @param CommandInterface $command
+     * @return mixed Response
+     *
+     * @throws ConnectionException
+     */
+    public function execute(CommandInterface $command)
+    {
+        return $this->connection->execute($command);
     }
 
     /**


### PR DESCRIPTION
When switching nodes, the prioritizer can recommend to stay on the current node.
The current node however could have lost its connection in the meantime.
In that case we will try and reconnect, or if not possible, connect to the next
best possible node.

The check whether the current node has disconnected has been moved so that
it is checked every time we execute any command, not just after the GETJOB
command.

I tried to write a test for this situation, but ended up with a brittle monster of a test depending on the order of method calls among several mocks. :-/