### PR TITLE
Add NOHANG support to GETJOB

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -675,6 +675,8 @@ Arguments:
      with the `WITHCOUNTERS` argument. The jobs will then contain two
      additional fields, the counters `nacks` and `additional-deliveries`
      for failure handling.
+  * `nohang`: a `bool`, if `true`, will prevent the command from blocking until
+     a job becomes available, returning instantly instead.
 
 Return value:
 

--- a/src/Command/GetJob.php
+++ b/src/Command/GetJob.php
@@ -60,7 +60,7 @@ class GetJob extends BaseCommand implements CommandInterface
     public function isBlocking()
     {
         $arguments = $this->getArguments();
-        $options = last($arguments);
+        $options = end($arguments);
         if (is_array($options) && isset($options['nohang']) && $options['nohang']) {
             return false;
         }

--- a/src/Command/GetJob.php
+++ b/src/Command/GetJob.php
@@ -23,6 +23,7 @@ class GetJob extends BaseCommand implements CommandInterface
      * @var array
      */
     protected $options = [
+        'nohang' => false,
         'count' => null,
         'timeout' => null,
         'withcounters' => false
@@ -34,6 +35,7 @@ class GetJob extends BaseCommand implements CommandInterface
      * @var array
      */
     protected $availableArguments = [
+        'nohang' => 'NOHANG',
         'timeout' => 'TIMEOUT',
         'count' => 'COUNT',
         'withcounters' => 'WITHCOUNTERS'
@@ -57,6 +59,11 @@ class GetJob extends BaseCommand implements CommandInterface
      */
     public function isBlocking()
     {
+        $arguments = $this->getArguments();
+        $options = last($arguments);
+        if (is_array($options) && isset($options['nohang']) && $options['nohang']) {
+            return false;
+        }
         return true;
     }
 

--- a/src/Command/GetJob.php
+++ b/src/Command/GetJob.php
@@ -61,7 +61,7 @@ class GetJob extends BaseCommand implements CommandInterface
     {
         $arguments = $this->getArguments();
         $options = end($arguments);
-        if (is_array($options) && isset($options['nohang']) && $options['nohang']) {
+        if (is_array($options) && !empty($options['nohang'])) {
             return false;
         }
         return true;

--- a/tests/Command/GetJobTest.php
+++ b/tests/Command/GetJobTest.php
@@ -136,6 +136,14 @@ class GetJobTest extends PHPUnit_Framework_TestCase
         $this->assertSame(['WITHCOUNTERS', 'FROM', 'q1', 'q2'], $result);
     }
 
+    public function testBuildOptionWithNohang()
+    {
+        $c = new GetJob();
+        $c->setArguments(['q1', 'q2', ['nohang' => true]]);
+        $result = $c->getArguments();
+        $this->assertSame(['NOHANG', 'FROM', 'q1', 'q2'], $result);
+    }
+
     public function testParseInvalidString()
     {
         $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\GetJob got: "test"');


### PR DESCRIPTION
Add support for `NOHANG` to `GETJOB`.

In the latest version of Disque, `GETJOB` can be called with the `NOHANG` option, which allows it to return immediately if no jobs are available. This PR adds support for that workflow.