### PR TITLE
Add support for QSTAT command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -895,7 +895,7 @@ Example call:
 
 ```php
 $count = $client->qlen('queue');
-var_dump($hello);
+var_dump($count);
 ```
 
 ### qpeek
@@ -979,6 +979,31 @@ do {
     var_dump($result['queues']);
     $cursor = $result['nextCursor'];
 } while (!$result['finished']);
+```
+
+### qstat
+
+Gets information about a queue. Signature:
+
+```php
+qstat(string $queue): array
+```
+
+Arguments:
+
+* `$queue`: The queue to get stats for.
+
+Return value:
+
+* `array`: An indexed array with statistics about the queue, including (but not
+    limited to) `name`, `len`, `age`, `idle`, `blocked`, `import-from`, `import-rate`,
+    `jobs-in`, `jobs-out`, `pause`
+
+Example call:
+
+```php
+$stats = $client->qstat('queue');
+var_dump($stats);
 ```
 
 ### show

--- a/src/Client.php
+++ b/src/Client.php
@@ -79,6 +79,7 @@ class Client
             new Command\QLen(),
             new Command\QPeek(),
             new Command\QScan(),
+            new Command\QStat(),
             new Command\Show(),
             new Command\Working()
         ] as $command) {

--- a/src/Command/QStat.php
+++ b/src/Command/QStat.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Disque\Command;
+
+use Disque\Command\Response\KeyValueResponse;
+use Disque\Exception;
+
+class QStat extends BaseCommand implements CommandInterface
+{
+    /**
+     * Tells the argument types for this command
+     *
+     * @var int
+     */
+    protected $argumentsType = self::ARGUMENTS_TYPE_STRING;
+
+    /**
+     * Tells which class handles the response
+     *
+     * @var int
+     */
+    protected $responseHandler = KeyValueResponse::class;
+
+    /**
+     * Get command
+     *
+     * @return string Command
+     */
+    public function getCommand()
+    {
+        return 'QSTAT';
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -84,6 +84,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
             new Command\QLen(),
             new Command\QPeek(),
             new Command\QScan(),
+            new Command\QStat(),
             new Command\Show(),
             new Command\Working()
         ];

--- a/tests/Command/QStatTest.php
+++ b/tests/Command/QStatTest.php
@@ -1,0 +1,98 @@
+<?php
+namespace Disque\Test\Command;
+
+use PHPUnit_Framework_TestCase;
+use Disque\Command\Argument\InvalidCommandArgumentException;
+use Disque\Command\CommandInterface;
+use Disque\Command\QStat;
+use Disque\Command\Response\InvalidResponseException;
+
+class QStatTest extends PHPUnit_Framework_TestCase
+{
+    public function testInstance()
+    {
+        $c = new QStat();
+        $this->assertInstanceOf(CommandInterface::class, $c);
+    }
+
+    public function testGetCommand()
+    {
+        $c = new QStat();
+        $result = $c->getCommand();
+        $this->assertSame('QSTAT', $result);
+    }
+
+    public function testIsBlocking()
+    {
+        $c = new QStat();
+        $result = $c->isBlocking();
+        $this->assertFalse($result);
+    }
+
+    public function testBuildInvalidArgumentsEmpty()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\QStat: []');
+        $c = new QStat();
+        $c->setArguments([]);
+    }
+
+    public function testBuildInvalidArgumentsEmptyTooMany()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\QStat: ["test","stuff"]');
+        $c = new QStat();
+        $c->setArguments(['test', 'stuff']);
+    }
+
+    public function testBuildInvalidArgumentsEmptyNonNumeric()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\QStat: {"test":"stuff"}');
+        $c = new QStat();
+        $c->setArguments(['test' => 'stuff']);
+    }
+
+    public function testBuildInvalidArgumentsNumericNon0()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\QStat: {"1":"stuff"}');
+        $c = new QStat();
+        $c->setArguments([1 => 'stuff']);
+    }
+
+    public function testBuildInvalidArgumentsNonString()
+    {
+        $this->setExpectedException(InvalidCommandArgumentException::class, 'Invalid command arguments. Arguments for command Disque\\Command\\QStat: [false]');
+        $c = new QStat();
+        $c->setArguments([false]);
+    }
+
+    public function testBuild()
+    {
+        $c = new QStat();
+        $c->setArguments(['test']);
+        $result = $c->getArguments();
+        $this->assertSame(['test'], $result);
+    }
+
+    public function testParseInvalidNonNumericArray()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\QStat got: ["test"]');
+        $c = new QStat();
+        $c->parse(['test']);
+    }
+
+    public function testParseInvalidNonNumericString()
+    {
+        $this->setExpectedException(InvalidResponseException::class, 'Invalid command response. Command Disque\\Command\\QStat got: "test"');
+        $c = new QStat();
+        $c->parse('test');
+    }
+
+    public function testParse()
+    {
+        $c = new QStat();
+        $result = $c->parse(['name', 'test', 'len', 1]);
+        $this->assertSame([
+            'name' => 'test',
+            'len' => 1
+        ], $result);
+    }
+}


### PR DESCRIPTION
The [`QSTAT` command](https://github.com/antirez/disque#qstat-queue-name) is useful for getting interesting queue statistics. I'm planning to use it in my disque monitoring project.

Attached: a `Command`, tests and documentation.

An example return value:

```
array (size=10)
  'name' => string 'test_queue_12431' (length=16)
  'len' => int 1
  'age' => int 1919
  'idle' => int 1919
  'blocked' => int 0
  'import-from' => 
    array (size=0)
      empty
  'import-rate' => int 0
  'jobs-in' => int 1
  'jobs-out' => int 0
  'pause' => string 'none' (length=4)
```