### PR TITLE
Return a K/V-like response for INFO, but with categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All Notable changes will be documented in this file. This project adheres to 
 [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- *BREAKING* `info()` now returns an associative array of information, rather
+than a large string.
+
 ## [2.0.3] - 2017-02-16
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -766,13 +766,36 @@ Arguments:
 
 Return value:
 
-* `string`: A big string with information about the connected node.
+* `array`: An associative array with information about the node, divided into
+    categories, such as: `Server`, `Clients`, `Memory`, `Jobs`, `Queues`, `Persistence`,
+    `Stats` and `CPU`. Each category contains a further associative array, with individual statistics.
 
 Example call:
 
 ```php
 $info = $client->info();
-echo $info;
+var_dump($info);
+/*
+prints: array (size=9)
+  'Server' =>
+    array (size=16)
+      'disque_version' => string '1.0-rc1' (length=7)
+      'disque_git_sha1' => string '00000000' (length=8)
+      'disque_git_dirty' => string '0' (length=1)
+      'disque_build_id' => string '1b9bed5f419fb409' (length=16)
+      'os' => string 'Linux 4.4.0-59-generic x86_64' (length=29)
+      'arch_bits' => string '64' (length=2)
+      [...]
+  'Clients' =>
+    array (size=4)
+      'connected_clients' => string '1' (length=1)
+      [...]
+  'Memory' =>
+    array (size=7)
+      'used_memory' => string '2336352' (length=7)
+      [...]
+      etc.
+*/
 ```
 
 ### jscan

--- a/src/Command/Info.php
+++ b/src/Command/Info.php
@@ -1,7 +1,7 @@
 <?php
 namespace Disque\Command;
 
-use Disque\Exception;
+use Disque\Command\Response\InfoResponse;
 
 class Info extends BaseCommand implements CommandInterface
 {
@@ -11,6 +11,13 @@ class Info extends BaseCommand implements CommandInterface
      * @var int
      */
     protected $argumentsType = self::ARGUMENTS_TYPE_EMPTY;
+
+    /**
+     * Tells which class handles the response
+     *
+     * @var int
+     */
+    protected $responseHandler = InfoResponse::class;
 
     /**
      * Get command

--- a/src/Command/Response/InfoResponse.php
+++ b/src/Command/Response/InfoResponse.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Disque\Command\Response;
+
+class InfoResponse extends BaseResponse implements ResponseInterface
+{
+    /**
+     * Set response body
+     *
+     * @param mixed $body Response body
+     * @return void
+     * @throws InvalidResponseException
+     */
+    public function setBody($body)
+    {
+        if ($body !== false && (empty($body) || !is_string($body))) {
+            throw new InvalidResponseException($this->command, $body);
+        }
+
+        parent::setBody($body);
+    }
+
+    /**
+     * Parse response
+     *
+     * Taken from https://github.com/nrk/predis/blob/v1.1/src/Command/ServerInfoV26x.php
+     *
+     * @return array Parsed response
+     */
+    public function parse()
+    {
+        if ($this->body === false || !is_string($this->body)) {
+            return null;
+        }
+
+        $data = $this->body;
+        $info = [];
+
+        $current = null;
+        $infoLines = preg_split('/\r?\n/', $data);
+
+        if (isset($infoLines[0]) && $infoLines[0][0] !== '#') {
+            return $this->parseSection($data);
+        }
+
+        foreach ($infoLines as $row) {
+            if ($row === '') {
+                continue;
+            }
+
+            if (preg_match('/^# (\w+)$/', $row, $matches)) {
+                $info[$matches[1]] = [];
+                $current = &$info[$matches[1]];
+                continue;
+            }
+
+            list($k, $v) = $this->parseRow($row);
+            $current[$k] = $v;
+        }
+
+        return $info;
+    }
+
+    protected function parseRow($row)
+    {
+        list($k, $v) = explode(':', $row, 2);
+        return [$k, $v];
+    }
+
+    protected function parseSection($data)
+    {
+        $info = [];
+        $infoLines = preg_split('/\r?\n/', $data);
+
+        foreach ($infoLines as $row) {
+            if (strpos($row, ':') === false) {
+                continue;
+            }
+
+            list($k, $v) = $this->parseRow($row);
+            $info[$k] = $v;
+        }
+
+        return $info;
+    }
+}

--- a/tests/Command/InfoTest.php
+++ b/tests/Command/InfoTest.php
@@ -55,6 +55,21 @@ class InfoTest extends PHPUnit_Framework_TestCase
     {
         $c = new Info();
         $result = $c->parse('test');
-        $this->assertSame('test', $result);
+        $this->assertSame([], $result);
+    }
+
+    public function testParseCategories()
+    {
+        $c = new Info();
+        $result = $c->parse("# Category\r\na:b\r\nfoo:bar\r\n\r\n# Baz\r\nwoop:shawoop\r\n");
+        $this->assertSame([
+            'Category' => [
+                'a' => 'b',
+                'foo' => 'bar',
+            ],
+            'Baz' => [
+                'woop' => 'shawoop',
+            ],
+        ], $result);
     }
 }


### PR DESCRIPTION
Instead of responding to `->info()` with a large string (`# Server\r\ndisque_version:1.0-rc1\r\ndisque_git_sha1:00000000\r\netc..`), lets parse the information nicely. The output is divided into sections by headings, so those end up as keys in an associative array. 

This approach is largely based on [the Predis `ServerInfoV26x.php` class](https://github.com/nrk/predis/blob/v1.1/src/Command/ServerInfoV26x.php) - so, thank @nrk for this.

This is a breaking change; anyone relying on `$client->info()` returning a string would be affected. So, this should probably wait until we have a 3.0 branch. (Happy to rebase the PR at that point.) Breaking change noted in the CHANGELOG.

Here's a `json_encode($client->info())`:

```json
{
    "Server": {
        "disque_version": "1.0-rc1",
        "disque_git_sha1": "00000000",
        "disque_git_dirty": "0",
        "disque_build_id": "1b9bed5f419fb409",
        "os": "Linux 4.4.0-59-generic x86_64",
        "arch_bits": "64",
        "multiplexing_api": "epoll",
        "gcc_version": "5.3.1",
        "process_id": "16542",
        "run_id": "5a58ee04afaa616f97746ff02eabf1ef14e2613d",
        "tcp_port": "7712",
        "uptime_in_seconds": "6426",
        "uptime_in_days": "0",
        "hz": "10",
        "executable": "\/home\/me\/blah\/disque-server",
        "config_file": ""
    },
    "Clients": {
        "connected_clients": "1",
        "client_longest_output_list": "0",
        "client_biggest_input_buf": "0",
        "blocked_clients": "0"
    },
    "Memory": {
        "used_memory": "2745152",
        "used_memory_human": "2.62M",
        "used_memory_rss": "11186176",
        "used_memory_peak": "2745152",
        "used_memory_peak_human": "2.62M",
        "mem_fragmentation_ratio": "4.07",
        "mem_allocator": "jemalloc-4.0.3"
    },
    "Jobs": {
        "registered_jobs": "3762"
    },
    "Queues": {
        "registered_queues": "1"
    },
    "Persistence": {
        "loading": "0",
        "aof_enabled": "0",
        "aof_state": "off",
        "aof_rewrite_in_progress": "0",
        "aof_rewrite_scheduled": "0",
        "aof_last_rewrite_time_sec": "-1",
        "aof_current_rewrite_time_sec": "-1",
        "aof_last_bgrewrite_status": "ok",
        "aof_last_write_status": "ok"
    },
    "Stats": {
        "total_connections_received": "1296",
        "total_commands_processed": "1346",
        "instantaneous_ops_per_sec": "0",
        "total_net_input_bytes": "99397",
        "total_net_output_bytes": "84372",
        "instantaneous_input_kbps": "0.01",
        "instantaneous_output_kbps": "0.19",
        "rejected_connections": "0",
        "latest_fork_usec": "0"
    },
    "CPU": {
        "used_cpu_sys": "409.21",
        "used_cpu_user": "7.42",
        "used_cpu_sys_children": "0.00",
        "used_cpu_user_children": "0.00"
    }
}
```