### PR TITLE
Pass cause exception through to Exception's __construct as $previous

### DIFF
--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -213,10 +213,13 @@ class Manager implements ManagerInterface
     {
         $servers = $this->credentials;
         shuffle($servers);
+        $previous = null;
+
         foreach ($servers as $server) {
             try {
                 $node = $this->getNodeConnection($server);
             } catch (ConnectionException $e) {
+                $previous = $e;
                 continue;
             }
 
@@ -225,7 +228,7 @@ class Manager implements ManagerInterface
             }
         }
 
-        throw new ConnectionException('No servers available');
+        throw new ConnectionException('No servers available', 0, $previous);
     }
 
     /**

--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -399,7 +399,7 @@ class Manager implements ManagerInterface
             try {
                 $this->switchNodeIfNeeded();
             } catch (ConnectionException $e) {
-                throw new ConnectionException('Not connected. ' . $e->getMessage());
+                throw new ConnectionException('Not connected. ' . $e->getMessage(), 0, $e);
             }
         }
     }

--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -321,6 +321,8 @@ class Manager implements ManagerInterface
             $this->nodeId
         );
 
+        $previous = null;
+
         // Try to connect by priority, continue on error, return on success
         foreach($sortedNodes as $nodeCandidate) {
             // If the first recommended node is our current node and it has
@@ -340,6 +342,7 @@ class Manager implements ManagerInterface
                     $nodeCandidate->connect();
                 }
             } catch (ConnectionException $e) {
+                $previous = $e;
                 continue;
             }
 
@@ -347,7 +350,7 @@ class Manager implements ManagerInterface
             return;
         }
 
-        throw new ConnectionException('Could not switch to any node');
+        throw new ConnectionException('Could not switch to any node', 0, $previous);
     }
 
     /**

--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -392,7 +392,7 @@ class Manager implements ManagerInterface
      * @return void
      * @throws ConnectionException
      */
-    private function shouldBeConnected()
+    protected function shouldBeConnected()
     {
         // If we lost the connection, first let's try and reconnect
         if (!$this->isConnected()) {

--- a/src/Connection/Node/Node.php
+++ b/src/Connection/Node/Node.php
@@ -251,7 +251,7 @@ class Node
              */
             $message = $e->getMessage();
             if (stripos($message, self::AUTH_REQUIRED_MESSAGE) === 0) {
-                throw new AuthenticationException($message);
+                throw new AuthenticationException($message, 0, $e);
             }
         }
 


### PR DESCRIPTION
Fixes #44 

No reason to go with 0 for the code argument (but that's the default value as is, so not a change.)