### PR TITLE
Prevent Socket::getType from returning null

### DIFF
--- a/src/Connection/Socket.php
+++ b/src/Connection/Socket.php
@@ -189,7 +189,8 @@ class Socket extends BaseConnection implements ConnectionInterface
      */
     private function getType($keepWaiting = false)
     {
-        $type = null;
+        $type = false;
+
         while (!feof($this->socket)) {
             $type = fgetc($this->socket);
             if ($type !== false && $type !== '') {


### PR DESCRIPTION
Fixes #49 